### PR TITLE
[Feature] Improve token storage persistence subject provider by utili…

### DIFF
--- a/src/Persistence/PersistenceSubjectAggregate.php
+++ b/src/Persistence/PersistenceSubjectAggregate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreyu\Bundle\DataTableBundle\Persistence;
+
+/**
+ * Persistence subject that holds a reference to an original subject.
+ */
+class PersistenceSubjectAggregate implements PersistenceSubjectInterface
+{
+    public function __construct(
+        private string $identifier,
+        private mixed $subject,
+    ) {
+    }
+
+    public function getDataTablePersistenceIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getSubject(): mixed
+    {
+        return $this->subject;
+    }
+}

--- a/src/Persistence/TokenStoragePersistenceSubjectProvider.php
+++ b/src/Persistence/TokenStoragePersistenceSubjectProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kreyu\Bundle\DataTableBundle\Persistence;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class TokenStoragePersistenceSubjectProvider implements PersistenceSubjectProviderInterface
 {
@@ -18,7 +19,17 @@ class TokenStoragePersistenceSubjectProvider implements PersistenceSubjectProvid
         $user = $this->tokenStorage->getToken()?->getUser();
 
         if ($user instanceof PersistenceSubjectInterface) {
-            return $user;
+            return new PersistenceSubjectAggregate(
+                $user->getDataTablePersistenceIdentifier(),
+                $user,
+            );
+        }
+
+        if ($user instanceof UserInterface) {
+            return new PersistenceSubjectAggregate(
+                $user->getUserIdentifier(),
+                $user,
+            );
         }
 
         throw PersistenceSubjectNotFoundException::createForProvider($this);


### PR DESCRIPTION
References #6 

Adds a `PersistenceSubjectAggregate`, that holds a reference to an original subject.

If user returned by the token storage implements the `Kreyu\Bundle\DataTableBundle\Persistence\PersistenceSubjectInterface`, the identifier returned by the `getDataTablePersistenceIdentifier()` method will be used. Otherwise, the value returned by the user's `getUserIdentifier()` method will be used.