### PR TITLE
[Feature] Allow adding HTML attributes to columns

### DIFF
--- a/docs/reference/columns/types/column.md
+++ b/docs/reference/columns/types/column.md
@@ -105,8 +105,8 @@ It is used to differentiate options for regular rendering, and excel rendering.
 For example, if you wish to display quantity column with "Quantity" label, but export with a "Qty" header:
 
 ```php
-$columns
-    ->add('quantity', NumberType::class, [
+$builder
+    ->addColumn('quantity', NumberType::class, [
         'label' => 'Quantity',
         'translation_domain' => 'product',
         'export' => [
@@ -136,8 +136,8 @@ it is possible to pass the option name to this array, to exclude it from the res
 For example:
 
 ```php
-$columns
-    ->add('id', CustomType::class, [
+$builder
+    ->addColumn('id', CustomType::class, [
         'uniqid' => fn (string $prefix) => uniqid($prefix),
         'non_resolvable_options' => [
             'uniqid',
@@ -152,4 +152,40 @@ The `uniqid` option will be available in the column views as a callable. For exa
 {% block kreyu_data_table_column_custom %}
     {{ value }} ({{ uniqid('product_') }})
 {% endblock %}
+```
+
+### `header_attr`
+
+**type**: `array` **default**: `[]`
+
+If you want to add extra attributes to an HTML column header representation (`<th>`) you can use the attr option. 
+It's an associative array with HTML attributes as keys. 
+This can be useful when you need to set a custom class for some column:
+
+```php
+$builder
+    ->addColumn('quantity', NumberType::class, [
+        'header_attr' => [
+            'class' => 'text-end',
+        ],
+    ])
+;
+```
+
+### `value_attr`
+
+**type**: `array` **default**: `[]`
+
+If you want to add extra attributes to an HTML column value representation (`<td>`) you can use the attr option.
+It's an associative array with HTML attributes as keys.
+This can be useful when you need to set a custom class for some column:
+
+```php
+$builder
+    ->addColumn('quantity', NumberType::class, [
+        'value_attr' => [
+            'class' => 'text-end',
+        ],
+    ])
+;
 ```

--- a/src/Column/Type/ColumnType.php
+++ b/src/Column/Type/ColumnType.php
@@ -44,6 +44,8 @@ final class ColumnType implements ColumnTypeInterface
                 'property_path' => null,
                 'property_accessor' => PropertyAccess::createPropertyAccessor(),
                 'getter' => null,
+                'header_attr' => [],
+                'value_attr' => [],
             ])
             ->setAllowedTypes('label', ['null', 'string', TranslatableMessage::class])
             ->setAllowedTypes('label_translation_parameters', ['array', Closure::class])
@@ -57,6 +59,8 @@ final class ColumnType implements ColumnTypeInterface
             ->setAllowedTypes('property_path', ['null', 'bool', 'string', PropertyPathInterface::class])
             ->setAllowedTypes('property_accessor', [PropertyAccessorInterface::class])
             ->setAllowedTypes('getter', ['null', Closure::class])
+            ->setAllowedTypes('header_attr', ['array'])
+            ->setAllowedTypes('value_attr', ['array'])
         ;
     }
 

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -100,13 +100,17 @@
 
 {% block kreyu_data_table_headers_row %}
     {% for column in columns %}
-        <th {{ block('attributes') }}>{{ data_table_column_header(column) }}</th>
+        <th {% with { attr: attr|default({})|merge(column.vars.header_attr) } %}{{ block('attributes') }}{% endwith %}>
+            {{ data_table_column_header(column) }}
+        </th>
     {% endfor %}
 {% endblock %}
 
 {% block kreyu_data_table_values_row %}
     {% for column in columns %}
-        <td {{ block('attributes') }}>{{- data_table_column_value(column) -}}</td>
+        <td {% with { attr: attr|default({})|merge(column.vars.value_attr) } %}{{ block('attributes') }}{% endwith %}>
+            {{- data_table_column_value(column) -}}
+        </td>
     {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
References #2 

Because columns are rendered in two segments: header and value, two new options are added:
- `header_attr`
- `value_attr`

Example usage:

```php
$builder
    ->addColumn('quantity', NumberType::class, [
        'header_attr' => [
            'class' => 'text-end',
        ],
        'value_attr' => [
            'class' => 'text-end',
        ],
    ])
;
```