### PR TITLE
v0.9.2

### DIFF
--- a/src/Bridge/Doctrine/Orm/Query/DoctrineOrmProxyQuery.php
+++ b/src/Bridge/Doctrine/Orm/Query/DoctrineOrmProxyQuery.php
@@ -64,7 +64,7 @@ class DoctrineOrmProxyQuery implements ProxyQueryInterface
             $field = $rootAlias.'.'.$field;
         }
 
-        $this->queryBuilder->orderBy($field, $direction->value);
+        $this->queryBuilder->addOrderBy($field, $direction->value);
     }
 
     public function paginate(PaginationData $paginationData): void

--- a/src/Maker/MakeDataTable.php
+++ b/src/Maker/MakeDataTable.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MakeDataTable extends AbstractMaker
 {
@@ -32,7 +33,7 @@ class MakeDataTable extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->addArgument('data-table-class', InputArgument::OPTIONAL, sprintf('Choose a name for your data table class (e.g. <fg=yellow>%sType</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('data-table-class', InputArgument::OPTIONAL, sprintf('Choose a name for your data table class (e.g. <fg=yellow>%sDataTableType</>)', Str::asClassName(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeDataTable.txt'))
         ;
     }
@@ -42,12 +43,13 @@ class MakeDataTable extends AbstractMaker
         $dataTableClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('data-table-class'),
             'DataTable\\Type\\',
-            'Type',
+            'DataTableType',
         );
 
         $useStatements = new UseStatementGenerator([
             AbstractDataTableType::class,
             DataTableBuilderInterface::class,
+            OptionsResolver::class,
         ]);
 
         $generator->generateClass(

--- a/src/Resources/help/MakeDataTable.txt
+++ b/src/Resources/help/MakeDataTable.txt
@@ -1,5 +1,5 @@
 The <info>%command.name%</info> command generates a new data table class.
 
-<info>php %command.full_name% AwesomeProjectType</info>
+<info>php %command.full_name% ProjectDataTableType</info>
 
 If the argument is missing, the command will ask for the data table class name interactively.

--- a/src/Resources/skeleton/DataTableType.tpl.php
+++ b/src/Resources/skeleton/DataTableType.tpl.php
@@ -6,9 +6,17 @@ namespace <?php echo $namespace; ?>;
 
 <?php echo $use_statements; ?>
 
-class <?php echo $class_name; ?> extends AbstractType
+class <?php echo $class_name; ?> extends AbstractDataTableType
 {
     public function buildDataTable(DataTableBuilderInterface $builder, array $options): void
     {
+        // Add columns, filters, actions, exporters here using the builder
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            // Configure your default data table options here
+        ]);
     }
 }


### PR DESCRIPTION
[Bugfix] Fix wrong extended class in MakeDataTable skeleton file (references #15)
[Bugfix] Change Doctrine ORM proxy query `sort()` method to use `addOrderBy()` instead of `orderBy()`

[Feature] Extend data table maker to include `configureOptions()` method as well as some comments