### PR TITLE
0.9.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "symfony/translation": "^6.0",
         "symfony/form": "^6.0",
         "symfony/mime": "^6.0",
-        "symfony/twig-bundle": "^6.0",
-        "phpstan/phpstan": "^1.10"
+        "symfony/twig-bundle": "^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
@@ -28,7 +27,8 @@
         "symfony/security-core": "^6.2",
         "phpoffice/phpspreadsheet": "^1.28",
         "doctrine/orm": "^2.15",
-        "doctrine/doctrine-bundle": "^2.9"
+        "doctrine/doctrine-bundle": "^2.9",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,17 @@
         "symfony/translation": "^6.0",
         "symfony/form": "^6.0",
         "symfony/mime": "^6.0",
-        "symfony/twig-bundle": "^6.0"
+        "symfony/twig-bundle": "^6.0",
+        "phpstan/phpstan": "^1.10"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.11",
-        "symfony/maker-bundle": "^1.48"
+        "symfony/maker-bundle": "^1.48",
+        "symfony/security-core": "^6.2",
+        "phpoffice/phpspreadsheet": "^1.28",
+        "doctrine/orm": "^2.15",
+        "doctrine/doctrine-bundle": "^2.9"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 5
+    checkGenericClassInNonGenericObjectType: false
+    excludePaths:
+        - src/Resources/skeleton/*
+        - src/DependencyInjection/Configuration.php

--- a/src/Bridge/Doctrine/Orm/Filter/Type/DateFilterType.php
+++ b/src/Bridge/Doctrine/Orm/Filter/Type/DateFilterType.php
@@ -97,6 +97,7 @@ class DateFilterType extends AbstractFilterType
             throw new \InvalidArgumentException(sprintf('Unable to convert data of type "%s" to DateTime object.', get_debug_type($value)));
         }
 
+        $dateTime = \DateTime::createFromInterface($dateTime);
         $dateTime->setTime(0, 0);
 
         return $dateTime;

--- a/src/Bridge/PhpSpreadsheet/Exporter/Type/PdfExporterType.php
+++ b/src/Bridge/PhpSpreadsheet/Exporter/Type/PdfExporterType.php
@@ -39,10 +39,11 @@ class PdfExporterType extends AbstractExporterType
 
     protected function getWriter(Spreadsheet $spreadsheet, array $options): IWriter
     {
-        $writer = match ($options['library']) {
+        $writer = match ($library = $options['library']) {
             'dompdf' => new Dompdf($spreadsheet),
             'mpdf' => new Mpdf($spreadsheet),
             'tcpdf' => new Tcpdf($spreadsheet),
+            default => throw new \LogicException(sprintf('Writer library "%s" is not supported', $library)),
         };
 
         $writer->setOrientation($options['orientation']);

--- a/src/Bridge/PhpSpreadsheet/Exporter/Type/PhpSpreadsheetExporterType.php
+++ b/src/Bridge/PhpSpreadsheet/Exporter/Type/PhpSpreadsheetExporterType.php
@@ -21,7 +21,7 @@ final class PhpSpreadsheetExporterType implements ExporterTypeInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         if (!class_exists(Spreadsheet::class)) {
-            throw new \LogicException(sprintf('Trying to use exporter that requires PhpSpreadsheet which is not installed. Try running "composer require phpoffice/phpspreadsheet".', static::class));
+            throw new \LogicException('Trying to use exporter that requires PhpSpreadsheet which is not installed. Try running "composer require phpoffice/phpspreadsheet".');
         }
 
         $resolver

--- a/src/Column/Type/FormColumnType.php
+++ b/src/Column/Type/FormColumnType.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Kreyu\Bundle\DataTableBundle\Column\Type;
 
 use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
-use Kreyu\Bundle\DataTableBundle\Column\ColumnView;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormColumnType extends AbstractColumnType
 {
-    public function buildView(ColumnView $view, ColumnInterface $column, array $options): void
+    public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
     {
         $view->vars = array_replace($view->vars, [
             'form' => $options['form'],

--- a/src/Column/Type/TemplateColumnType.php
+++ b/src/Column/Type/TemplateColumnType.php
@@ -4,20 +4,10 @@ declare(strict_types=1);
 
 namespace Kreyu\Bundle\DataTableBundle\Column\Type;
 
-use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
-use Kreyu\Bundle\DataTableBundle\Column\ColumnView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TemplateColumnType extends AbstractColumnType
 {
-    public function buildView(ColumnView $view, ColumnInterface $column, array $options): void
-    {
-        $view->vars = array_replace($view->vars, [
-            'template_path' => $options['template_path'],
-            'template_vars' => $options['template_vars'],
-        ]);
-    }
-
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -350,7 +350,7 @@ class DataTable implements DataTableInterface
         $data = null;
 
         if ($this->config->isPaginationPersistenceEnabled()) {
-            $data ??= $this->getPersistenceData('pagination');
+            $data = $this->getPersistenceData('pagination');
         }
 
         $data ??= $this->config->getDefaultPaginationData();
@@ -369,7 +369,7 @@ class DataTable implements DataTableInterface
         $data = null;
 
         if ($this->config->isSortingPersistenceEnabled()) {
-            $data ??= $this->getPersistenceData('sorting');
+            $data = $this->getPersistenceData('sorting');
         }
 
         $data ??= $this->config->getDefaultSortingData();
@@ -388,7 +388,7 @@ class DataTable implements DataTableInterface
         $data = null;
 
         if ($this->config->isFiltrationPersistenceEnabled()) {
-            $data ??= $this->getPersistenceData('filtration');
+            $data = $this->getPersistenceData('filtration');
         }
 
         $data ??= $this->config->getDefaultFiltrationData();
@@ -409,7 +409,7 @@ class DataTable implements DataTableInterface
         $data = null;
 
         if ($this->config->isPersonalizationPersistenceEnabled()) {
-            $data ??= $this->getPersistenceData('personalization');
+            $data = $this->getPersistenceData('personalization');
         }
 
         $data ??= $this->config->getDefaultPersonalizationData();

--- a/src/DataTableControllerTrait.php
+++ b/src/DataTableControllerTrait.php
@@ -4,51 +4,10 @@ declare(strict_types=1);
 
 namespace Kreyu\Bundle\DataTableBundle;
 
-use JetBrains\PhpStorm\ArrayShape;
-use Kreyu\Bundle\DataTableBundle\Type\DataTableType;
-use Kreyu\Bundle\DataTableBundle\Type\DataTableTypeInterface;
-use Symfony\Contracts\Service\Attribute\Required;
-
+/**
+ * @deprecated since 0.9.3, use {@see DataTableFactoryAwareTrait} instead
+ */
 trait DataTableControllerTrait
 {
-    private null|DataTableFactoryInterface $dataTableFactory = null;
-
-    #[Required]
-    public function setDataTableFactory(?DataTableFactoryInterface $dataTableFactory): void
-    {
-        $this->dataTableFactory = $dataTableFactory;
-    }
-
-    /**
-     * @param class-string<DataTableTypeInterface> $type
-     */
-    protected function createDataTable(string $type, mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableInterface
-    {
-        if (null === $this->dataTableFactory) {
-            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
-        }
-
-        return $this->dataTableFactory->create($type, $query, $options);
-    }
-
-    /**
-     * @param class-string<DataTableTypeInterface> $type
-     */
-    protected function createNamedDataTable(string $name, string $type, mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableInterface
-    {
-        if (null === $this->dataTableFactory) {
-            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
-        }
-
-        return $this->dataTableFactory->createNamed($name, $type, $query, $options);
-    }
-
-    protected function createDataTableBuilder(mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableBuilderInterface
-    {
-        if (null === $this->dataTableFactory) {
-            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
-        }
-
-        return $this->dataTableFactory->createBuilder(DataTableType::class, $query, $options);
-    }
+    use DataTableFactoryAwareTrait;
 }

--- a/src/DataTableFactoryAwareTrait.php
+++ b/src/DataTableFactoryAwareTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreyu\Bundle\DataTableBundle;
+
+use JetBrains\PhpStorm\ArrayShape;
+use Kreyu\Bundle\DataTableBundle\Type\DataTableType;
+use Kreyu\Bundle\DataTableBundle\Type\DataTableTypeInterface;
+use Symfony\Contracts\Service\Attribute\Required;
+
+trait DataTableFactoryAwareTrait
+{
+    private null|DataTableFactoryInterface $dataTableFactory = null;
+
+    #[Required]
+    public function setDataTableFactory(?DataTableFactoryInterface $dataTableFactory): void
+    {
+        $this->dataTableFactory = $dataTableFactory;
+    }
+
+    /**
+     * @param class-string<DataTableTypeInterface> $type
+     */
+    protected function createDataTable(string $type, mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableInterface
+    {
+        if (null === $this->dataTableFactory) {
+            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
+        }
+
+        return $this->dataTableFactory->create($type, $query, $options);
+    }
+
+    /**
+     * @param class-string<DataTableTypeInterface> $type
+     */
+    protected function createNamedDataTable(string $name, string $type, mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableInterface
+    {
+        if (null === $this->dataTableFactory) {
+            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
+        }
+
+        return $this->dataTableFactory->createNamed($name, $type, $query, $options);
+    }
+
+    protected function createDataTableBuilder(mixed $query = null, #[ArrayShape(DataTableType::DEFAULT_OPTIONS)] array $options = []): DataTableBuilderInterface
+    {
+        if (null === $this->dataTableFactory) {
+            throw new \LogicException(sprintf('You cannot use the "%s" method on controller without data table factory.', __METHOD__));
+        }
+
+        return $this->dataTableFactory->createBuilder(DataTableType::class, $query, $options);
+    }
+}

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -43,6 +43,8 @@ interface DataTableInterface
 
     public function createPersonalizationFormBuilder(DataTableView $view = null): FormBuilderInterface;
 
+    public function createExportFormBuilder(): FormBuilderInterface;
+
     public function isExporting(): bool;
 
     public function hasActiveFilters(): bool;

--- a/src/Exporter/ExportData.php
+++ b/src/Exporter/ExportData.php
@@ -14,7 +14,7 @@ class ExportData
     public ExportStrategy $strategy;
     public bool $includePersonalization;
 
-    public static function fromArray(array $data): static
+    public static function fromArray(array $data): self
     {
         $resolver = (new OptionsResolver())
             ->setRequired('exporter')

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -6,12 +6,17 @@ namespace Kreyu\Bundle\DataTableBundle\Filter;
 
 use Kreyu\Bundle\DataTableBundle\DataTableView;
 use Kreyu\Bundle\DataTableBundle\Filter\Type\ResolvedFilterTypeInterface;
+use Kreyu\Bundle\DataTableBundle\Query\ProxyQueryInterface;
 
 interface FilterInterface
 {
+    public function apply(ProxyQueryInterface $query, FilterData $data): void;
+
     public function getName(): string;
 
     public function getFormName(): string;
+
+    public function getFormOptions(): array;
 
     public function getQueryPath(): string;
 

--- a/src/Filter/FiltrationData.php
+++ b/src/Filter/FiltrationData.php
@@ -30,7 +30,7 @@ class FiltrationData
      * - an instance of {@see FilterData}
      * - an array of filter data
      */
-    public static function fromArray(array $data): static
+    public static function fromArray(array $data): self
     {
         $filters = [];
 
@@ -46,14 +46,14 @@ class FiltrationData
             $filters[$key] = $value;
         }
 
-        return new static($filters);
+        return new self($filters);
     }
 
     /**
      * Creates a new instance from a {@see DataTableInterface}.
      * The filters are be initialized with empty values.
      */
-    public static function fromDataTable(DataTableInterface $dataTable): static
+    public static function fromDataTable(DataTableInterface $dataTable): self
     {
         $filters = [];
 
@@ -61,7 +61,7 @@ class FiltrationData
             $filters[$filter->getName()] = new FilterData();
         }
 
-        return new static($filters);
+        return new self($filters);
     }
 
     /**

--- a/src/Filter/Form/Type/FiltrationDataType.php
+++ b/src/Filter/Form/Type/FiltrationDataType.php
@@ -48,12 +48,9 @@ class FiltrationDataType extends AbstractType implements DataMapperInterface
          */
         $dataTable = $options['data_table'];
 
-        /**
-         * @var DataTableView $dataTableView
-         */
         $dataTableView = $options['data_table_view'];
 
-        if (null === $dataTableView) {
+        if (!$dataTableView instanceof DataTableView) {
             throw new \LogicException('Unable to create filtration form view without the data table view.');
         }
 

--- a/src/Filter/Type/ResolvedFilterType.php
+++ b/src/Filter/Type/ResolvedFilterType.php
@@ -14,6 +14,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ResolvedFilterType implements ResolvedFilterTypeInterface
 {
+    private OptionsResolver $optionsResolver;
+
     /**
      * @param array<FilterTypeExtensionInterface> $typeExtensions
      */

--- a/src/Maker/MakeDataTable.php
+++ b/src/Maker/MakeDataTable.php
@@ -37,7 +37,7 @@ class MakeDataTable extends AbstractMaker
         ;
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $dataTableClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('data-table-class'),

--- a/src/Pagination/PaginationData.php
+++ b/src/Pagination/PaginationData.php
@@ -15,7 +15,10 @@ class PaginationData
     ) {
     }
 
-    public static function fromArray(array $data): static
+    /**
+     * @param array{page: int, perPage: int} $data
+     */
+    public static function fromArray(array $data): self
     {
         ($resolver = new OptionsResolver())
             ->setDefault('page', null)

--- a/src/Pagination/PaginationInterface.php
+++ b/src/Pagination/PaginationInterface.php
@@ -9,6 +9,9 @@ interface PaginationInterface
     public const DEFAULT_PAGE = 1;
     public const DEFAULT_PER_PAGE = 25;
 
+    /**
+     * @return iterable<object>
+     */
     public function getItems(): iterable;
 
     public function getCurrentPageNumber(): int;

--- a/src/Persistence/PersistenceSubjectInterface.php
+++ b/src/Persistence/PersistenceSubjectInterface.php
@@ -6,5 +6,5 @@ namespace Kreyu\Bundle\DataTableBundle\Persistence;
 
 interface PersistenceSubjectInterface
 {
-    public function getDataTablePersistenceIdentifier();
+    public function getDataTablePersistenceIdentifier(): string;
 }

--- a/src/Persistence/PersistenceSubjectNotFoundException.php
+++ b/src/Persistence/PersistenceSubjectNotFoundException.php
@@ -11,8 +11,8 @@ class PersistenceSubjectNotFoundException extends \Exception
         parent::__construct($message);
     }
 
-    public static function createForProvider(PersistenceSubjectProviderInterface $provider): static
+    public static function createForProvider(PersistenceSubjectProviderInterface $provider): self
     {
-        return new static(sprintf('Persistence subject not found by the "%s"', get_class($provider)));
+        return new self(sprintf('Persistence subject not found by the "%s"', get_class($provider)));
     }
 }

--- a/src/Personalization/Form/Type/PersonalizationDataType.php
+++ b/src/Personalization/Form/Type/PersonalizationDataType.php
@@ -25,10 +25,9 @@ class PersonalizationDataType extends AbstractType
 
     public function finishView(FormView $view, FormInterface $form, array $options): void
     {
-        /**
-         * @var DataTableView $dataTableView
-         */
-        if (null === $dataTableView = $options['data_table_view']) {
+        $dataTableView = $options['data_table_view'];
+
+        if (!$dataTableView instanceof DataTableView) {
             throw new \LogicException('Unable to create personalization form view without the data table view.');
         }
 

--- a/src/Personalization/PersonalizationColumnData.php
+++ b/src/Personalization/PersonalizationColumnData.php
@@ -14,7 +14,10 @@ class PersonalizationColumnData
     public int $order;
     public bool $visible;
 
-    public static function fromArray(array $data): static
+    /**
+     * @param array{name: string, order: int, visible: bool} $data
+     */
+    public static function fromArray(array $data): self
     {
         ($resolver = new OptionsResolver())
             ->setRequired('name')
@@ -37,7 +40,7 @@ class PersonalizationColumnData
 
         $data = $resolver->resolve($data);
 
-        $self = new static();
+        $self = new self();
         $self->name = $data['name'];
         $self->order = $data['order'];
         $self->visible = $data['visible'];
@@ -45,9 +48,9 @@ class PersonalizationColumnData
         return $self;
     }
 
-    public static function fromColumn(ColumnInterface $column, int $order = 0, bool $visible = true): static
+    public static function fromColumn(ColumnInterface $column, int $order = 0, bool $visible = true): self
     {
-        $self = new static();
+        $self = new self();
         $self->name = $column->getName();
         $self->order = $order;
         $self->visible = $visible;

--- a/src/Personalization/PersonalizationData.php
+++ b/src/Personalization/PersonalizationData.php
@@ -15,6 +15,9 @@ class PersonalizationData
      */
     private array $columns = [];
 
+    /**
+     * @param array<PersonalizationColumnData> $columns
+     */
     public function __construct(array $columns = [])
     {
         foreach ($columns as $column) {
@@ -23,9 +26,9 @@ class PersonalizationData
     }
 
     /**
-     * Creates a new instance of personalization data from an array.
+     * @param array<string, ColumnInterface>|array<string, array<string, mixed>> $data
      */
-    public static function fromArray(array $data): static
+    public static function fromArray(array $data): self
     {
         $columns = [];
 
@@ -40,7 +43,7 @@ class PersonalizationData
             $columns[$key] = $value;
         }
 
-        return new static($columns);
+        return new self($columns);
     }
 
     /**
@@ -48,7 +51,7 @@ class PersonalizationData
      * The columns are be added in order they are defined in the data table.
      * Every column is marked as "visible" by default.
      */
-    public static function fromDataTable(DataTableInterface $dataTable): static
+    public static function fromDataTable(DataTableInterface $dataTable): self
     {
         $columns = [];
 
@@ -56,7 +59,7 @@ class PersonalizationData
             $columns[] = PersonalizationColumnData::fromColumn($column, $index);
         }
 
-        return new static($columns);
+        return new self($columns);
     }
 
     /**

--- a/src/Sorting/SortingColumnData.php
+++ b/src/Sorting/SortingColumnData.php
@@ -15,6 +15,10 @@ class SortingColumnData
     ) {
     }
 
+    /**
+     * @param  array{name: string, direction: string} $data
+     * @return self
+     */
     public static function fromArray(array $data): self
     {
         ($resolver = new OptionsResolver())

--- a/src/Sorting/SortingData.php
+++ b/src/Sorting/SortingData.php
@@ -14,6 +14,9 @@ class SortingData
      */
     private array $columns = [];
 
+    /**
+     * @param array<SortingColumnData> $columns
+     */
     public function __construct(array $columns = [])
     {
         foreach ($columns as $column) {
@@ -41,6 +44,9 @@ class SortingData
         return new self($fields);
     }
 
+    /**
+     * @return array<SortingColumnData>
+     */
     public function getColumns(): array
     {
         return $this->columns;

--- a/src/Twig/DataTableExtension.php
+++ b/src/Twig/DataTableExtension.php
@@ -21,6 +21,9 @@ use Twig\TwigFunction;
 
 class DataTableExtension extends AbstractExtension
 {
+    /**
+     * @param array<string> $themes
+     */
     public function __construct(
         private array $themes,
     ) {
@@ -58,6 +61,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderDataTable(Environment $environment, DataTableView $view, array $variables = []): string
@@ -70,6 +74,8 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $dataTableVariables
+     * @param  array<string, mixed> $formVariables
      * @throws TwigException|\Throwable
      */
     public function renderDataTableFormAware(Environment $environment, DataTableView $view, FormView $formView, array $dataTableVariables = [], array $formVariables = []): string
@@ -82,6 +88,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderDataTableTable(Environment $environment, DataTableView $view, array $variables = []): string
@@ -94,6 +101,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderDataTableActionBar(Environment $environment, DataTableView $view, array $variables = []): string
@@ -106,6 +114,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderHeaderRow(Environment $environment, HeaderRowView $view, array $variables = []): string
@@ -118,6 +127,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderValueRow(Environment $environment, ValueRowView $view, array $variables = []): string
@@ -130,6 +140,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderColumnLabel(Environment $environment, ColumnHeaderView $view, array $variables = []): string
@@ -142,6 +153,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderColumnHeader(Environment $environment, ColumnHeaderView $view, array $variables = []): string
@@ -154,6 +166,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderColumnValue(Environment $environment, ColumnValueView $view, array $variables = []): string
@@ -166,6 +179,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderAction(Environment $environment, ActionView $view, array $variables = []): string
@@ -178,6 +192,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
      * @throws TwigException|\Throwable
      */
     public function renderPagination(Environment $environment, DataTableView|PaginationView $view, array $variables = []): string
@@ -248,6 +263,7 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $context
      * @throws TwigException|\Throwable
      */
     private function renderBlock(Environment $environment, string $blockName, array $context = []): string
@@ -266,6 +282,8 @@ class DataTableExtension extends AbstractExtension
     }
 
     /**
+     * @param  array<string, mixed> $variables
+     * @return array<string, mixed>
      * @throws TwigException|\Throwable
      */
     private function getDecoratedViewContext(Environment $environment, ColumnHeaderView|ColumnValueView|ActionView $view, array $variables, string $prefix, string $suffix): array

--- a/src/Type/DataTableType.php
+++ b/src/Type/DataTableType.php
@@ -6,6 +6,7 @@ namespace Kreyu\Bundle\DataTableBundle\Type;
 
 use Kreyu\Bundle\DataTableBundle\Action\ActionFactoryInterface;
 use Kreyu\Bundle\DataTableBundle\Action\ActionInterface;
+use Kreyu\Bundle\DataTableBundle\Action\ActionView;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnFactoryInterface;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
 use Kreyu\Bundle\DataTableBundle\DataTableBuilderInterface;
@@ -15,6 +16,8 @@ use Kreyu\Bundle\DataTableBundle\Exporter\ExporterFactoryInterface;
 use Kreyu\Bundle\DataTableBundle\Exporter\Form\Type\ExportDataType;
 use Kreyu\Bundle\DataTableBundle\Filter\FilterData;
 use Kreyu\Bundle\DataTableBundle\Filter\FilterFactoryInterface;
+use Kreyu\Bundle\DataTableBundle\Filter\FilterInterface;
+use Kreyu\Bundle\DataTableBundle\Filter\FilterView;
 use Kreyu\Bundle\DataTableBundle\HeaderRowView;
 use Kreyu\Bundle\DataTableBundle\Pagination\PaginationView;
 use Kreyu\Bundle\DataTableBundle\Persistence\PersistenceAdapterInterface;
@@ -104,9 +107,7 @@ final class DataTableType implements DataTableTypeInterface
         $columns = $visibleColumns = $dataTable->getConfig()->getColumns();
 
         if ($dataTable->getConfig()->isPersonalizationEnabled()) {
-            if ($personalizationData = $dataTable->getPersonalizationData()) {
-                $visibleColumns = $personalizationData->compute($columns);
-            }
+            $visibleColumns = $dataTable->getPersonalizationData()->compute($columns);
         }
 
         $view->vars = array_replace($view->vars, [
@@ -210,6 +211,9 @@ final class DataTableType implements DataTableTypeInterface
         return new PaginationView($view, $dataTable->getPagination());
     }
 
+    /**
+     * @return array<ActionView>
+     */
     private function createActionViews(DataTableView $view, DataTableInterface $dataTable): array
     {
         return array_map(
@@ -218,14 +222,15 @@ final class DataTableType implements DataTableTypeInterface
         );
     }
 
+    /**
+     * @return array<FilterView>
+     */
     private function createFilterViews(DataTableView $view, DataTableInterface $dataTable): array
     {
         $filters = [];
 
-        $filtrationData = $dataTable->getFiltrationData();
-
         foreach ($dataTable->getConfig()->getFilters() as $filter) {
-            $data = $filtrationData?->getFilterData($filter->getName()) ?? new FilterData();
+            $data = $dataTable->getFiltrationData()->getFilterData($filter->getName()) ?? new FilterData();
 
             $filters[$filter->getName()] = $filter->createView($data, $view);
         }
@@ -253,7 +258,8 @@ final class DataTableType implements DataTableTypeInterface
     }
 
     /**
-     * @param array<ColumnInterface> $columns
+     * @param  array<ColumnInterface> $columns
+     * @return array<ValueRowView>
      */
     private function createValueRowsViews(DataTableView $view, DataTableInterface $dataTable, array $columns): array
     {

--- a/src/Type/DataTableTypeInterface.php
+++ b/src/Type/DataTableTypeInterface.php
@@ -11,8 +11,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 interface DataTableTypeInterface
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildDataTable(DataTableBuilderInterface $builder, array $options): void;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(DataTableView $view, DataTableInterface $dataTable, array $options): void;
 
     public function configureOptions(OptionsResolver $resolver): void;

--- a/src/Type/ResolvedDataTableType.php
+++ b/src/Type/ResolvedDataTableType.php
@@ -24,7 +24,7 @@ class ResolvedDataTableType implements ResolvedDataTableTypeInterface
     public function __construct(
         private DataTableTypeInterface $innerType,
         private array $typeExtensions = [],
-        private ?ResolvedDataTableType $parent = null,
+        private ?ResolvedDataTableTypeInterface $parent = null,
     ) {
     }
 

--- a/src/Type/ResolvedDataTableTypeFactoryInterface.php
+++ b/src/Type/ResolvedDataTableTypeFactoryInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Kreyu\Bundle\DataTableBundle\Type;
 
+use Kreyu\Bundle\DataTableBundle\Extension\DataTableTypeExtensionInterface;
+
 interface ResolvedDataTableTypeFactoryInterface
 {
+    /**
+     * @param array<DataTableTypeExtensionInterface> $typeExtensions
+     */
     public function createResolvedType(DataTableTypeInterface $type, array $typeExtensions, ResolvedDataTableTypeInterface $parent = null): ResolvedDataTableTypeInterface;
 }

--- a/src/Type/ResolvedDataTableTypeInterface.php
+++ b/src/Type/ResolvedDataTableTypeInterface.php
@@ -25,12 +25,21 @@ interface ResolvedDataTableTypeInterface
      */
     public function getTypeExtensions(): array;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function createBuilder(DataTableFactoryInterface $factory, string $name, ?ProxyQueryInterface $query = null, array $options = []): DataTableBuilderInterface;
 
     public function createView(DataTableInterface $dataTable): DataTableView;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildDataTable(DataTableBuilderInterface $builder, array $options): void;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(DataTableView $view, DataTableInterface $dataTable, array $options): void;
 
     public function getOptionsResolver(): OptionsResolver;


### PR DESCRIPTION
- added PHPStan as dev dependency, fixed all level 5 errors;
- deprecated DataTableControllerTrait, use DataTableFactoryAwareTrait
- fixed deprecation: "Creation of dynamic property Kreyu\Bundle\DataTableBundle\Filter\Type\ResolvedFilterType::$optionsResolver is deprecated"