### PR TITLE
a11y: Added title attribute to action buttons

### DIFF
--- a/src/Resources/views/themes/bootstrap_5.html.twig
+++ b/src/Resources/views/themes/bootstrap_5.html.twig
@@ -138,6 +138,7 @@
         'data-bs-target': '#' ~ filtration_form.vars.id ~ '__collapse',
         'aria-expanded': 'false',
         'aria-controls': filtration_form.vars.id ~ '__collapse',
+        'title': 'Filter'|trans({}, 'KreyuDataTable'),
     }|merge(attr|default({})) %}
 
     <button {{ block('attributes') }}>{{ block('action_filter_icon') }}</button>
@@ -155,6 +156,7 @@
         'type': 'button',
         'data-bs-toggle': 'modal',
         'data-bs-target': '#' ~ export_form.vars.id ~ '__modal',
+        'title': 'Export'|trans({}, 'KreyuDataTable'),
     }|merge(attr|default({})) %}
 
     <button {{ block('attributes') }}>{{ block('action_export_icon') }}</button>
@@ -172,6 +174,7 @@
         'type': 'button',
         'data-bs-toggle': 'modal',
         'data-bs-target': '#' ~ personalization_form.vars.id ~ '__modal',
+        'title': 'Personalize'|trans({}, 'KreyuDataTable'),
     }|merge(attr|default({})) %}
 
     <button {{ block('attributes') }}>{{ block('action_personalize_icon') }}</button>

--- a/src/Resources/views/themes/tabler.html.twig
+++ b/src/Resources/views/themes/tabler.html.twig
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block action_filter %}
-    {% with { attr: { class: 'btn btn-primary btn-icon' } } %}
+    {% with { attr: { class: 'btn btn-primary btn-icon', title: 'Filter'|trans({}, 'KreyuDataTable') } } %}
         {{ parent() }}
     {% endwith %}
 {% endblock %}
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block action_export %}
-    {% with { attr: { class: 'btn btn-primary btn-icon' } } %}
+    {% with { attr: { class: 'btn btn-primary btn-icon', title: 'Export'|trans({}, 'KreyuDataTable') } } %}
         {{ parent() }}
     {% endwith %}
 {% endblock %}
@@ -64,7 +64,7 @@
 {% endblock %}
 
 {% block action_personalize %}
-    {% with { attr: { class: 'btn btn-primary btn-icon' } } %}
+    {% with { attr: { class: 'btn btn-primary btn-icon', title: 'Personalize'|trans({}, 'KreyuDataTable') } } %}
         {{ parent() }}
     {% endwith %}
 {% endblock %}


### PR DESCRIPTION
Added a `title` attribute to filter, export and personalize action buttons for Bootstrap 5 and Tabler themes.