### PR TITLE
fix: incorrect fallback to the base type templates in columns and actions

### DIFF
--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -109,15 +109,15 @@
 {% endblock %}
 
 {% block kreyu_data_table_column_header %}
-    {{ block(block_name, block_theme) }}
+    {{ block(block_name, block_theme ?? theme) }}
 {% endblock %}
 
 {% block kreyu_data_table_column_value %}
-    {{ block(block_name, block_theme) }}
+    {{ block(block_name, block_theme ?? theme) }}
 {% endblock %}
 
 {% block kreyu_data_table_action %}
-    {% if visible %}{{- block(block_name, block_theme) -}}{% endif %}
+    {% if visible %}{{- block(block_name, block_theme ?? theme) -}}{% endif %}
 {% endblock %}
 
 {# Pagination #}

--- a/src/Twig/DataTableExtension.php
+++ b/src/Twig/DataTableExtension.php
@@ -344,7 +344,11 @@ class DataTableExtension extends AbstractExtension
         $context['block_name'] = $prefix.'_'.$suffix;
 
         foreach ($view->vars['block_prefixes'] as $blockPrefix) {
-            $blockName = $prefix.'_'.$blockPrefix.'_'.$suffix;
+            $blockName = $blockPrefix.'_'.$suffix;
+
+            if ($prefix !== $blockPrefix) {
+                $blockName = $prefix.'_'.$blockName;
+            }
 
             foreach ($dataTable->vars['themes'] as $theme) {
                 $wrapper = $environment->load($theme);


### PR DESCRIPTION
Currently, the rendering process was trying to fallback to incorrect block name of the base column and action types. For example, instead of `column_value`, it was trying to render the `column_column_value`.