### PR TITLE
Fix confirmation behavior on LinkActionType

### DIFF
--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -495,7 +495,13 @@
 {% endblock %}
 
 {% block action_link_value %}
-    <a {% with { attr: { href, target }|merge(attr) } %}{{- block('attributes') -}}{% endwith %}>
+    {% set attr = { href, target }|merge(attr|default({})) %}
+
+    {% if batch %}
+        {% set attr = { 'data-kreyu--data-table-bundle--batch-target': 'identifierHolder' }|merge(attr) %}
+    {% endif %}
+
+    <a {% with { attr } %}{{- block('attributes') -}}{% endwith %}>
         {% with { attr: {} } %}{{- block('action_value', theme, _context) -}}{% endwith %}
     </a>
 {% endblock %}

--- a/src/Resources/views/themes/bootstrap_5.html.twig
+++ b/src/Resources/views/themes/bootstrap_5.html.twig
@@ -634,17 +634,23 @@
 {% endblock %}
 
 {% block action_link_value %}
-    {% set attr = { class: 'text-decoration-none' ~ (label ? ' me-2' : '') } %}
+    {% set attr = { class: 'text-decoration-none' ~ (label ? ' me-2' : '') }|merge(attr) %}
 
     {% if confirmation %}
         {% set attr = {
             'data-bs-toggle': 'modal',
             'data-bs-target': '#' ~ confirmation.identifier,
-        }|merge(attr|default({})) %}
+        }|merge(attr) %}
 
-        {% with { attr: action_confirmation_modal_attr|default({}) } %}
-            {{ block('action_confirmation_modal') }}
-        {% endwith %}
+        {% set confirm_button_attr = { href }|merge(confirm_button_attr|default({})) %}
+
+        {% if batch %}
+            {% set confirm_button_attr = {
+                'data-kreyu--data-table-bundle--batch-target': 'identifierHolder',
+            }|merge(confirm_button_attr) %}
+        {% endif %}
+
+        {% with { attr, confirm_button_attr } %}{{ block('action_confirmation_modal') }}{% endwith %}
     {% endif %}
 
     {{ parent() }}


### PR DESCRIPTION
Confirmation dialog with LinkActionType not working.

Proposed patch copy the behavior from block `action_button_value`

Note : with this patch, `action_link_value` and `action_button_value` in `base.html.twig` has now duplicate code. It might be refactored.