### PR TITLE
fix: Doctrine ORM result set looping on the past page #77

### DIFF
--- a/src/Bridge/Doctrine/Orm/Query/DoctrineOrmResultSetFactory.php
+++ b/src/Bridge/Doctrine/Orm/Query/DoctrineOrmResultSetFactory.php
@@ -46,15 +46,18 @@ class DoctrineOrmResultSetFactory implements DoctrineOrmResultSetFactoryInterfac
                 ->setMaxResults($maxResults)
                 ->setFirstResult($firstResult);
 
+            $itemCount = 0;
+
             foreach ($paginator as $item) {
                 yield $item;
 
                 $hasItems = true;
 
                 ++$cursorPosition;
+                ++$itemCount;
             }
 
-            $firstResult += $cursorPosition;
+            $firstResult += $itemCount;
 
             $paginator->getQuery()->getEntityManager()->clear();
         }

--- a/src/Bridge/Doctrine/Orm/Query/DoctrineOrmResultSetFactory.php
+++ b/src/Bridge/Doctrine/Orm/Query/DoctrineOrmResultSetFactory.php
@@ -54,7 +54,7 @@ class DoctrineOrmResultSetFactory implements DoctrineOrmResultSetFactoryInterfac
                 ++$cursorPosition;
             }
 
-            $firstResult = $cursorPosition;
+            $firstResult += $cursorPosition;
 
             $paginator->getQuery()->getEntityManager()->clear();
         }


### PR DESCRIPTION
References issue described in #77 

The `DoctrineOrmResultSetFactory` class, responsible for creating a result set and its iterator, was incorrectly setting the query's first result (offset), which introduced a bug visible on the last page of results.

For example, if last page contains 22 rows, but each page displays 25 max, the factory would (incorrectly) iterate one more time, adding another 25 rows, starting from offset of 22 records.