### PR TITLE
Corrected translation string when no results are found

### DIFF
--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -76,7 +76,7 @@
 
 {% block table_body_row_no_results %}
     <tr>
-        <td colspan="{{ column_count }}" {% with { attr: table_body_row_no_results_attr|default({}) } %}{{- block('attributes') -}}{% endwith %}>{{ 'No results'|trans({}, 'KreyuDataTable') }}</td>
+        <td colspan="{{ column_count }}" {% with { attr: table_body_row_no_results_attr|default({}) } %}{{- block('attributes') -}}{% endwith %}>{{ 'No results found'|trans({}, 'KreyuDataTable') }}</td>
     </tr>
 {% endblock %}
 


### PR DESCRIPTION
Translation strings are defined as "No results found"