### PR TITLE
Fix TraceableDataTableFactory not creating properly named data tables

### DIFF
--- a/src/Debug/TraceableDataTableFactory.php
+++ b/src/Debug/TraceableDataTableFactory.php
@@ -28,7 +28,7 @@ class TraceableDataTableFactory implements DataTableFactoryInterface
 
     public function createNamed(string $name, string $type, mixed $data = null, array $options = []): DataTableInterface
     {
-        $dataTable = $this->dataTableFactory->create($type, $data, $options);
+        $dataTable = $this->dataTableFactory->createNamed($name, $type, $data, $options);
 
         $this->dataCollector->collectDataTable($dataTable);
 


### PR DESCRIPTION
The current implementation of `TraceableDataTableFactory` introduced an issue where its `createNamed()` method was calling the decorated factory `create()` method instead of `createNamed()`.