### PR TITLE
Removing label auto camelToSentence from ActionType

### DIFF
--- a/src/Action/Type/ActionType.php
+++ b/src/Action/Type/ActionType.php
@@ -9,7 +9,6 @@ use Kreyu\Bundle\DataTableBundle\Action\ActionContext;
 use Kreyu\Bundle\DataTableBundle\Action\ActionInterface;
 use Kreyu\Bundle\DataTableBundle\Action\ActionView;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
-use Kreyu\Bundle\DataTableBundle\Util\StringUtil;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatableInterface;

--- a/src/Action/Type/ActionType.php
+++ b/src/Action/Type/ActionType.php
@@ -70,7 +70,7 @@ final class ActionType implements ActionTypeInterface
             'data_table' => $dataTable,
             'name' => $action->getName(),
             'block_prefixes' => $blockPrefixes,
-            'label' => $options['label'] ?? StringUtil::camelToSentence($action->getName()),
+            'label' => $options['label'] ?? $action->getName(),
             'translation_domain' => $options['translation_domain'] ?? $dataTable->vars['translation_domain'],
             'translation_parameters' => $options['translation_parameters'],
             'attr' => $options['attr'],


### PR DESCRIPTION
Hello, 

First, thanks for your bundle, it is amazing work ! I am testing it and it looks very good.
I tried to create some rows action with customs labels : 
```php
$builder    
  ->addAction('Create a new Product', ButtonActionType::class, [
      'href' => $this->router->generate('app_product_new'),
      
  ])
  ->addRowAction('Editing a Product', ButtonActionType::class, [
      'href' => function (Product $product) {
          return $this->router->generate('app_product_edit', ['id' => $product->getId()]);
      },
  ])
  ->addRowAction('Deleting a Product', ButtonActionType::class, [
      'confirmation' => true,
      'href' => function (Product $product) {
          return $this->router->generate('app_product_delete', ['id' => $product->getId()]);
      },
  ]);
```
But when i wanted to render it :



![with](https://github.com/user-attachments/assets/4b11e2ca-e3b9-4619-8f59-436bd8788be4)

it looks like it is always calling the camelToSentence function, but for label maybe we could let user select their own text ?

With this very small PR : 
![without](https://github.com/user-attachments/assets/bf7d3dbe-c42a-4fd2-9f11-fa8399166fa3)
 