### PR TITLE
Fix invalid loop break in DataTableFactory

### DIFF
--- a/src/DataTableFactory.php
+++ b/src/DataTableFactory.php
@@ -37,9 +37,8 @@ class DataTableFactory implements DataTableFactoryInterface
             foreach ($this->registry->getProxyQueryFactories() as $proxyQueryFactory) {
                 if ($proxyQueryFactory->supports($data)) {
                     $query = $proxyQueryFactory->create($data);
+                    break;
                 }
-
-                break;
             }
         }
 


### PR DESCRIPTION
The loop should break after the first proxy query factory matches. With break outside of the if statement, if the first proxy query factory does not support the given data, it would break the loop, creating more issues.