### PR TITLE
Pass row data as second argument of the "formatter" column option

### DIFF
--- a/docs/src/reference/types/column/options/column.md
+++ b/docs/src/reference/types/column/options/column.md
@@ -116,7 +116,9 @@ Formats the value to the desired string.
 ```php
 $builder
     ->addColumn('quantity', NumberColumnType::class, [
-        'formatter' => fn (float $value) => number_format($value, 2) . 'kg',
+        'formatter' => function (float $value, Product $product, ColumnInterface $column, array $options) {
+            return number_format($value, 2) . $product->getUnit();
+        },
     ])
 ;
 ```


### PR DESCRIPTION
Currently, the `formatter` option supports two arguments:
1. `data` of the column
2. an instance of the column

Getting an instance of the column as second argument should be moved to the third argument.

Second argument should receive row data instead:

```php
'formatter' => function (string $fullName, User $user, ColumnInterface $column, array $options) {
    // ...
}
```