### PR TITLE
[POC] Add a modal action whose content is loaded via an HTTP call.

### DIFF
--- a/assets/controllers/batch.js
+++ b/assets/controllers/batch.js
@@ -90,10 +90,15 @@ export default class extends Controller {
 
     #updateIdentifierHolderHref(identifierHolder, identifierMap) {
         let href;
+        let hrefHolder =  'href';
+
+        if (identifierHolder.dataset.hrefHolder !== undefined) {
+            hrefHolder = identifierHolder.dataset.hrefHolder;
+        }
 
         try {
-            href = new URL(identifierHolder.href);
-        } catch (exception) {
+            href = new URL(identifierHolder.dataset[hrefHolder]);
+        } catch (exception) {console.log(exception)
             return;
         }
 
@@ -111,7 +116,7 @@ export default class extends Controller {
             }
         }
 
-        identifierHolder.href = href.toString();
+        identifierHolder.dataset[hrefHolder] = href.toString();
     }
 
     #updateIdentifierHolderDataParam(identifierHolder, identifierMap) {

--- a/assets/controllers/batch.js
+++ b/assets/controllers/batch.js
@@ -98,7 +98,7 @@ export default class extends Controller {
 
         try {
             href = new URL(identifierHolder.dataset[hrefHolder]);
-        } catch (exception) {console.log(exception)
+        } catch (exception) {
             return;
         }
 

--- a/assets/controllers/batch.js
+++ b/assets/controllers/batch.js
@@ -97,7 +97,7 @@ export default class extends Controller {
         }
 
         try {
-            href = new URL(identifierHolder.dataset[hrefHolder]);
+            href = new URL(identifierHolder.dataset[hrefHolder], window.location.origin);
         } catch (exception) {
             return;
         }

--- a/assets/controllers/bootstrap/modal.js
+++ b/assets/controllers/bootstrap/modal.js
@@ -1,0 +1,27 @@
+import { Controller } from '@hotwired/stimulus';
+import { Modal } from 'bootstrap'; // Import Bootstrap
+
+export default class extends Controller {
+    static targets = ['modal'];
+
+    static values = {
+        url: String,
+    }
+
+    open(event) {
+        event.preventDefault();
+        const modalContent = this.modalTarget;
+
+        fetch(this.urlValue)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Error loading content.');
+                }
+                return response.text();
+            })
+            .then(html => {
+                modalContent.innerHTML = html;
+            })
+        ;
+    }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,6 +19,11 @@
                 "main": "controllers/state.js",
                 "fetch": "eager",
                 "enabled": true
+            },
+            "bootstrap-modal": {
+                "main": "controllers/bootstrap/modal.js",
+                "fetch": "eager",
+                "enabled": true
             }
         },
         "importmap": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -23,7 +23,7 @@
             "bootstrap-modal": {
                 "main": "controllers/bootstrap/modal.js",
                 "fetch": "eager",
-                "enabled": true
+                "enabled": false
             }
         },
         "importmap": {

--- a/src/Action/Type/ModalActionType.php
+++ b/src/Action/Type/ModalActionType.php
@@ -40,7 +40,7 @@ final class ModalActionType extends AbstractActionType
             }
         }
 
-        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params'], RouterInterface::ABSOLUTE_URL);
+        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params']);
 
         $view->vars = array_replace($view->vars, [
             'href' => $href,

--- a/src/Action/Type/ModalActionType.php
+++ b/src/Action/Type/ModalActionType.php
@@ -40,7 +40,7 @@ final class ModalActionType extends AbstractActionType
             }
         }
 
-        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params']);
+        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params'], RouterInterface::ABSOLUTE_URL);
 
         $view->vars = array_replace($view->vars, [
             'href' => $href,
@@ -51,7 +51,8 @@ final class ModalActionType extends AbstractActionType
     {
         $resolver
             ->define('route')
-            ->allowedTypes('string', 'callable')
+            ->default(null)
+            ->allowedTypes('null', 'string', 'callable')
         ;
 
         $resolver
@@ -62,7 +63,8 @@ final class ModalActionType extends AbstractActionType
 
         $resolver
             ->define('href')
-            ->allowedTypes('string', 'callable')
+            ->default(null)
+            ->allowedTypes('null', 'string', 'callable')
         ;
     }
 }

--- a/src/Action/Type/ModalActionType.php
+++ b/src/Action/Type/ModalActionType.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreyu\Bundle\DataTableBundle\Action\Type;
+
+use Kreyu\Bundle\DataTableBundle\Action\ActionInterface;
+use Kreyu\Bundle\DataTableBundle\Action\ActionView;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
+use Kreyu\Bundle\DataTableBundle\Exception\LogicException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
+
+final class ModalActionType extends AbstractActionType
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    public function buildView(ActionView $view, ActionInterface $action, array $options): void
+    {
+        if (null === $options['href'] && null === $options['route']) {
+            throw new LogicException('No "route" or "href" provided.');
+        }
+
+        if ($view->parent instanceof ColumnValueView) {
+            $value = $view->parent->value;
+
+            foreach (['href', 'route', 'route_params'] as $optionName) {
+                if (isset($options[$optionName]) && is_callable($options[$optionName])) {
+                    $options[$optionName] = $options[$optionName]($value);
+                }
+            }
+        } else {
+            foreach (['href', 'route', 'route_params'] as $optionName) {
+                if (isset($options[$optionName]) && is_callable($options[$optionName])) {
+                    throw new LogicException(sprintf('Callable used for option "%s", but it\'s only available for RowActions.', $optionName));
+                }
+            }
+        }
+
+        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params']);
+
+        $view->vars = array_replace($view->vars, [
+            'href' => $href,
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->define('route')
+            ->allowedTypes('string', 'callable')
+        ;
+
+        $resolver
+            ->define('route_params')
+            ->allowedTypes('array', 'callable')
+            ->default([])
+        ;
+
+        $resolver
+            ->define('href')
+            ->allowedTypes('string', 'callable')
+        ;
+    }
+}

--- a/src/Action/Type/ModalActionType.php
+++ b/src/Action/Type/ModalActionType.php
@@ -9,12 +9,12 @@ use Kreyu\Bundle\DataTableBundle\Action\ActionView;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
 use Kreyu\Bundle\DataTableBundle\Exception\LogicException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class ModalActionType extends AbstractActionType
 {
     public function __construct(
-        private readonly RouterInterface $router,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -40,7 +40,7 @@ final class ModalActionType extends AbstractActionType
             }
         }
 
-        $href = $options['href'] ?? $this->router->generate($options['route'], $options['route_params']);
+        $href = $options['href'] ?? $this->urlGenerator->generate($options['route'], $options['route_params']);
 
         $view->vars = array_replace($view->vars, [
             'href' => $href,

--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -68,7 +68,7 @@ return static function (ContainerConfigurator $configurator) {
     $services
         ->set('kreyu_data_table.action.type.modal', ModalActionType::class)
         ->tag('kreyu_data_table.action.type')
-        ->args([UrlGeneratorInterface::class])
+        ->args([service(UrlGeneratorInterface::class)])
     ;
 
     $services

--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -10,6 +10,7 @@ use Kreyu\Bundle\DataTableBundle\Action\Type\ActionType;
 use Kreyu\Bundle\DataTableBundle\Action\Type\ButtonActionType;
 use Kreyu\Bundle\DataTableBundle\Action\Type\FormActionType;
 use Kreyu\Bundle\DataTableBundle\Action\Type\LinkActionType;
+use Kreyu\Bundle\DataTableBundle\Action\Type\ModalActionType;
 use Kreyu\Bundle\DataTableBundle\Action\Type\ResolvedActionTypeFactory;
 use Kreyu\Bundle\DataTableBundle\Action\Type\ResolvedActionTypeFactoryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -59,5 +60,11 @@ return static function (ContainerConfigurator $configurator) {
     $services
         ->set('kreyu_data_table.action.type.form', FormActionType::class)
         ->tag('kreyu_data_table.action.type')
+    ;
+
+    $services
+        ->set('kreyu_data_table.action.type.modal', ModalActionType::class)
+        ->tag('kreyu_data_table.action.type')
+        ->args([service('router')])
     ;
 };

--- a/src/Resources/translations/KreyuDataTable.en.yaml
+++ b/src/Resources/translations/KreyuDataTable.en.yaml
@@ -51,3 +51,4 @@ Action confirmation: Action execution confirmation
 Are you sure you want to execute this action?: Are you sure you want to execute this action?
 Confirm: Confirm
 Cancel: Cancel
+Loading: Loading

--- a/src/Resources/translations/KreyuDataTable.fr.yaml
+++ b/src/Resources/translations/KreyuDataTable.fr.yaml
@@ -50,3 +50,4 @@ Action confirmation: Confirmation de l'action
 Are you sure you want to execute this action?: Êtes-vous sûr de vouloir exécuter cette action ?
 Confirm: Confirmer
 Cancel: Annuler
+Loading: Chargement

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -632,6 +632,18 @@
     </form>
 {% endblock %}
 
+{% block action_modal_control %}
+    {% set attr = { dataUrl }|filter(v => v != null)|merge(attr|default({})) %}
+
+    {% if batch %}
+        {% set attr = { 'data-kreyu--data-table-bundle--batch-target': 'identifierHolder' }|merge(attr) %}
+    {% endif %}
+
+    <button {% with { attr } %}{{- block('attributes') -}}{% endwith %}>
+        {% with { attr: {} } %}{{- block('action_control', theme, _context) -}}{% endwith %}
+    </button>
+{% endblock %}
+
 {% block sort_arrow_none %}{% endblock %}
 
 {% block sort_arrow_asc %}↑{% endblock %}

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -633,7 +633,7 @@
 {% endblock %}
 
 {% block action_modal_control %}
-    {% set attr = { dataUrl }|filter(v => v != null)|merge(attr|default({})) %}
+    {% set attr = { href }|filter(v => v != null)|merge(attr|default({})) %}
 
     {% if batch %}
         {% set attr = { 'data-kreyu--data-table-bundle--batch-target': 'identifierHolder' }|merge(attr) %}

--- a/src/Resources/views/themes/bootstrap_5.html.twig
+++ b/src/Resources/views/themes/bootstrap_5.html.twig
@@ -723,6 +723,32 @@
     {% endif %}
 {% endblock %}
 
+
+{% block action_modal_control %}
+<div
+    data-controller="kreyu--data-table-bundle--bootstrap-modal"
+    data-kreyu--data-table-bundle--bootstrap-modal-url-value="{{ dataUrl }}"
+>
+    {% set modalId = 'modalId-' ~ random() %}
+    <button
+            data-action="kreyu--data-table-bundle--bootstrap-modal#open"
+            type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#{{ modalId }}">
+        {% with { attr: {} } %}{{- block('action_control', theme, _context) -}}{% endwith %}
+    </button>
+
+    <div class="modal fade" id="{{ modalId }}" tabindex="-1" aria-labelledby="{{ modalId }}Label" aria-hidden="true"
+         data-kreyu--data-table-bundle--bootstrap-modal-target="modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    Loading...
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
 {% block sort_arrow_none %}
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-expand" viewBox="0 0 16 16">
         <path fill-rule="evenodd" d="M3.646 9.146a.5.5 0 0 1 .708 0L8 12.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708zm0-2.292a.5.5 0 0 0 .708 0L8 3.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708z"/>

--- a/src/Resources/views/themes/bootstrap_5.html.twig
+++ b/src/Resources/views/themes/bootstrap_5.html.twig
@@ -746,7 +746,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-body">
-                    Loading...
+                    {{ 'Loading'|trans }}
                 </div>
             </div>
         </div>

--- a/src/Resources/views/themes/bootstrap_5.html.twig
+++ b/src/Resources/views/themes/bootstrap_5.html.twig
@@ -727,7 +727,12 @@
 {% block action_modal_control %}
 <div
     data-controller="kreyu--data-table-bundle--bootstrap-modal"
-    data-kreyu--data-table-bundle--bootstrap-modal-url-value="{{ dataUrl }}"
+    data-kreyu--data-table-bundle--bootstrap-modal-url-value="{{ href }}"
+
+    {% if batch %}
+        data-kreyu--data-table-bundle--batch-target="identifierHolder"
+        data-href-holder="kreyu-DataTableBundle-BootstrapModalUrlValue"
+    {% endif %}
 >
     {% set modalId = 'modalId-' ~ random() %}
     <button


### PR DESCRIPTION
Hey !

Here is a POC I created to experiment with the bundle.

The idea is to open a modal with content loaded asynchronously. For instance, this could be used to display the details of a product without redirecting to another page. This is a feature I use frequently in my projects.

I left the `base.html.twig` theme "as is" since I didn’t add any custom JavaScript to it. Depending on the user’s theme, it should be possible to open any kind of modal.

Here’s an example of how I implemented it:
```PHP
$builder->addRowAction('View detail', ModalActionType::class, [
    'route' => 'app_product_detail',
    'route_params' => function(Product $product) {
        return ['id' => $product->getId()];
    },
])
->addBatchAction('Batch modal', ModalActionType::class, [
    'route' => 'app_product_batch_detail',
])
->addAction('View global detail', ModalActionType::class, [
    'route' => 'app_product_global_detail',
]);
```

This is the way I use it in my test project. As you can see, you can either use the `route`/`route_params` options or the `href` one, as discussed in another issue.
**Unfortunately I didn't manage to get the `BatchAction` working properly**. Ideally, I would like to send the selected rows with the HTTP call.

The controller’s response must return raw HTML, like this:
```PHP
//src/Controller/ProductController
#[Route('/{id}', name: 'app_product_detail')]
public function detail(Product $product): Response
{
    return $this->render('product/detail.html.twig', [
        'product' => $product,
    ]);
}
```
```Twig
{# product/detail.html.twig #}
<div class="modal-dialog">
    <div class="modal-content">
        <div class="modal-header">
            <h5 class="modal-title">Ok, this loads properly !</h5>
            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
        </div>
        <div class="modal-body">
            <p>Here is the result of the AJAX request. The product name is : {{ product.name }}</p>
        </div>
        <div class="modal-footer">
            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
        </div>
    </div>
</div>
```

And this is the result:
![image](https://github.com/user-attachments/assets/088c4020-d4b2-41b9-95cf-59971a4915d6)

Using this kind of modal, it's even possible to manage a form in a modal. Thanks to a little bit of JavaScript (e.g., Stimulus :eyes: ), you can refresh the form, display errors, submit it, and redirect to user properly afterward.

What do you think about it ? 

I’m not a huge fan of having the controller in a subfolder. Since it’s tightly coupled to Bootstrap 5, I’m not quite sure how to handle this in the most appropriate way. Any suggestions?