### PR TITLE
Add badge option to column types

### DIFF
--- a/docs/src/reference/types/column/enum.md
+++ b/docs/src/reference/types/column/enum.md
@@ -16,6 +16,23 @@ The [`EnumColumnType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/
 Formats the enum value. If Symfony Translator component is available, and the enum implements [`TranslatableInterface`](https://github.com/symfony/translation-contracts/blob/main/TranslatableInterface.php),
 the enum will be translated. Otherwise, the enum name will be displayed.
 
+### `badge`
+
+- **type**: `bool`, `string`, or `callable`
+- **default**: `false`
+
+Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.
+
+Example usage:
+
+```php
+$builder
+    ->addColumn('status', EnumColumnType::class, [
+        'badge' => 'primary',
+    ])
+;
+```
+
 ## Inherited options
 
 <ColumnTypeOptions excludedOptions="['formatter']"/>

--- a/docs/src/reference/types/column/money.md
+++ b/docs/src/reference/types/column/money.md
@@ -95,6 +95,23 @@ For more details, see:
 - [Intl number formatter documentation](https://www.php.net/manual/en/class.numberformatter.php)
 - [Twig `format_currency` filter documentation](https://twig.symfony.com/doc/2.x/filters/format_currency.html)
 
+### `badge`
+
+- **type**: `bool`, `string`, or `callable`
+- **default**: `false`
+
+Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.
+
+Example usage:
+
+```php
+$builder
+    ->addColumn('price', MoneyColumnType::class, [
+        'badge' => 'primary',
+    ])
+;
+```
+
 ## Inherited options
 
 <ColumnTypeOptions/>

--- a/src/Column/Type/BooleanColumnType.php
+++ b/src/Column/Type/BooleanColumnType.php
@@ -16,7 +16,13 @@ final class BooleanColumnType extends AbstractColumnType
         $view->vars = array_replace($view->vars, [
             'label_true' => $options['label_true'],
             'label_false' => $options['label_false'],
+            'badge' => $options['badge'],
         ]);
+
+        if ($options['badge']) {
+            $badgeClass = is_callable($options['badge']) ? $options['badge']($view->data) : $options['badge'];
+            $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' badge ' . $badgeClass);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -26,11 +32,14 @@ final class BooleanColumnType extends AbstractColumnType
                 'label_true' => 'Yes',
                 'label_false' => 'No',
                 'value_translation_domain' => 'KreyuDataTable',
+                'badge' => false,
             ])
             ->setAllowedTypes('label_true', ['string', TranslatableInterface::class])
             ->setAllowedTypes('label_false', ['string', TranslatableInterface::class])
+            ->setAllowedTypes('badge', ['bool', 'string', 'callable'])
             ->setInfo('label_true', 'Label displayed when the value equals true.')
             ->setInfo('label_false', 'Label displayed when the value equals false.')
+            ->setInfo('badge', 'Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.')
         ;
     }
 }

--- a/src/Column/Type/DateTimeColumnType.php
+++ b/src/Column/Type/DateTimeColumnType.php
@@ -16,7 +16,13 @@ final class DateTimeColumnType extends AbstractColumnType
         $view->vars = array_replace($view->vars, [
             'format' => $options['format'],
             'timezone' => $options['timezone'],
+            'badge' => $options['badge'],
         ]);
+
+        if ($options['badge']) {
+            $badgeClass = is_callable($options['badge']) ? $options['badge']($view->data) : $options['badge'];
+            $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' badge ' . $badgeClass);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -25,6 +31,7 @@ final class DateTimeColumnType extends AbstractColumnType
             ->setDefaults([
                 'format' => 'd.m.Y H:i:s',
                 'timezone' => null,
+                'badge' => false,
             ])
             ->setNormalizer('export', function (Options $options, $value) {
                 if (true === $value) {
@@ -47,8 +54,10 @@ final class DateTimeColumnType extends AbstractColumnType
             })
             ->setAllowedTypes('format', ['string'])
             ->setAllowedTypes('timezone', ['null', 'string'])
+            ->setAllowedTypes('badge', ['bool', 'string', 'callable'])
             ->setInfo('format', 'A date time string format, supported by the PHP date() function.')
             ->setInfo('timezone', 'A timezone used to render the date time as string.')
+            ->setInfo('badge', 'Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.')
         ;
     }
 

--- a/src/Column/Type/LinkColumnType.php
+++ b/src/Column/Type/LinkColumnType.php
@@ -23,7 +23,13 @@ final class LinkColumnType extends AbstractColumnType
         $view->vars = array_replace($view->vars, [
             'href' => $href,
             'target' => $target,
+            'badge' => $options['badge'],
         ]);
+
+        if ($options['badge']) {
+            $badgeClass = is_callable($options['badge']) ? $options['badge']($view->data) : $options['badge'];
+            $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' badge ' . $badgeClass);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -32,9 +38,12 @@ final class LinkColumnType extends AbstractColumnType
             ->setDefaults([
                 'href' => '#',
                 'target' => null,
+                'badge' => false,
             ])
             ->setAllowedTypes('href', ['string', 'callable'])
             ->setAllowedTypes('target', ['null', 'string', 'callable'])
+            ->setAllowedTypes('badge', ['bool', 'string', 'callable'])
+            ->setInfo('badge', 'Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.')
         ;
     }
 

--- a/src/Column/Type/NumberColumnType.php
+++ b/src/Column/Type/NumberColumnType.php
@@ -16,7 +16,13 @@ final class NumberColumnType extends AbstractColumnType
         $view->vars = array_merge($view->vars, [
             'use_intl_formatter' => $options['use_intl_formatter'],
             'intl_formatter_options' => $options['intl_formatter_options'],
+            'badge' => $options['badge'],
         ]);
+
+        if ($options['badge']) {
+            $badgeClass = is_callable($options['badge']) ? $options['badge']($view->data) : $options['badge'];
+            $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' badge ' . $badgeClass);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -34,8 +40,11 @@ final class NumberColumnType extends AbstractColumnType
                         ->setAllowedTypes('style', 'string')
                     ;
                 },
+                'badge' => false,
             ])
             ->setAllowedTypes('use_intl_formatter', 'bool')
+            ->setAllowedTypes('badge', ['bool', 'string', 'callable'])
+            ->setInfo('badge', 'Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.')
         ;
     }
 

--- a/src/Column/Type/TextColumnType.php
+++ b/src/Column/Type/TextColumnType.php
@@ -4,7 +4,32 @@ declare(strict_types=1);
 
 namespace Kreyu\Bundle\DataTableBundle\Column\Type;
 
+use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 final class TextColumnType extends AbstractColumnType
 {
-    // ...
+    public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
+    {
+        $view->vars = array_replace($view->vars, [
+            'badge' => $options['badge'],
+        ]);
+
+        if ($options['badge']) {
+            $badgeClass = is_callable($options['badge']) ? $options['badge']($view->data) : $options['badge'];
+            $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' badge ' . $badgeClass);
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'badge' => false,
+            ])
+            ->setAllowedTypes('badge', ['bool', 'string', 'callable'])
+            ->setInfo('badge', 'Defines whether the value should be rendered as a badge. Can be a boolean, string, or callable.')
+        ;
+    }
 }


### PR DESCRIPTION
Related to #166

Add badge option to various column types to display text as a badge.

* **BooleanColumnType**:
  - Add `badge` option to `configureOptions` method.
  - Update `buildValueView` method to handle `badge` option.

* **TextColumnType**:
  - Add `badge` option to `configureOptions` method.
  - Update `buildValueView` method to handle `badge` option.

* **DateTimeColumnType**:
  - Add `badge` option to `configureOptions` method.
  - Update `buildValueView` method to handle `badge` option.

* **NumberColumnType**:
  - Add `badge` option to `configureOptions` method.
  - Update `buildValueView` method to handle `badge` option.

* **LinkColumnType**:
  - Add `badge` option to `configureOptions` method.
  - Update `buildValueView` method to handle `badge` option.

* **Documentation**:
  - Add documentation for `badge` option in `money.md`.
  - Add documentation for `badge` option in `enum.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kreyu/data-table-bundle/issues/166?shareId=XXXX-XXXX-XXXX-XXXX).