### PR TITLE
fix: render raw separator if separator_html is true

### DIFF
--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -560,11 +560,7 @@
                     {%- set separator = separator|trans -%}
                 {%- endif -%}
 
-                {%- if separator_html -%}
-                    {%- set separator = separator|raw -%}
-                {%- endif -%}
-
-                {{ separator }}
+                {{ separator_html ? separator|raw : separator }}
             {%- endif -%}
         </span>
     {%- endfor %}


### PR DESCRIPTION
You implemented the `separator_html` part of my feature request #207 with https://github.com/Kreyu/data-table-bundle/commit/ec4b110bf26b30cc5aaeac9583489fc20e13ece8 and then directly broke it with the next commit when allowing it to be translatable https://github.com/Kreyu/data-table-bundle/commit/88433d743870e817abf35f4040943e4a4203f011 😄

Using the `raw` filter must happen inside the curly braces where the value is rendered.