### PR TITLE
Fix ChoiceType filter with multiple/expanded options (2nd attempt)

### DIFF
--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -46,7 +46,7 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
 
     private function getFilterClearQueryParameters(FilterView $filterView): array
     {
-        $value = $filterView->data?->getValue();
+        $value = isset($filterView->data) ? $filterView->data->getValue() : null;
         if (is_array($value)) {
             $parameters = ['value' => array_map(fn () => '', $value)];
         } else {

--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -46,7 +46,7 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
 
     private function getFilterClearQueryParameters(FilterView $filterView): array
     {
-        $parameters = ['value' => ''];
+        $parameters = ['value' => null];
 
         if ($filterView->vars['operator_selectable']) {
             $parameters['operator'] = null;

--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -46,7 +46,7 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
 
     private function getFilterClearQueryParameters(FilterView $filterView): array
     {
-        $value = isset($filterView->data) ? $filterView->data?->getValue() : null;
+        $value = isset($filterView->data) ? $filterView->data->getValue() : null;
         if (is_array($value)) {
             $parameters = ['value' => array_map(fn () => '', $value)];
         } else {

--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -46,7 +46,12 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
 
     private function getFilterClearQueryParameters(FilterView $filterView): array
     {
-        $parameters = ['value' => null];
+        $value = $filterView->data?->getValue();
+        if (is_array($value)) {
+            $parameters = ['value' => array_map(fn () => '', $value)];
+        } else {
+            $parameters = ['value' => ''];
+        }
 
         if ($filterView->vars['operator_selectable']) {
             $parameters['operator'] = null;

--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -46,7 +46,7 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
 
     private function getFilterClearQueryParameters(FilterView $filterView): array
     {
-        $value = isset($filterView->data) ? $filterView->data->getValue() : null;
+        $value = isset($filterView->data) ? $filterView->data?->getValue() : null;
         if (is_array($value)) {
             $parameters = ['value' => array_map(fn () => '', $value)];
         } else {

--- a/src/Filter/FilterData.php
+++ b/src/Filter/FilterData.php
@@ -59,6 +59,6 @@ class FilterData
 
     public function hasValue(): bool
     {
-        return null !== $this->value && '' !== $this->value;
+        return (bool) $this->value;
     }
 }

--- a/src/Filter/FilterData.php
+++ b/src/Filter/FilterData.php
@@ -59,6 +59,6 @@ class FilterData
 
     public function hasValue(): bool
     {
-        return (bool) $this->value;
+        return null !== $this->value && '' !== $this->value && [] !== $this->value;
     }
 }

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -16,9 +16,11 @@ class FormUtil
             $value = [];
 
             foreach ($view->children as $child) {
-                if (in_array($child->vars['name'], array_keys($view->vars['value'] ?? []))) {
-                    $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
+                if (isset($child->vars['checked']) && false === $child->vars['checked']) {
+                    continue;
                 }
+
+                $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
             }
         }
 

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -16,7 +16,7 @@ class FormUtil
             $value = [];
 
             foreach ($view->children as $child) {
-                if ($child->vars['data']) {
+                if (null === $child->vars['data']) {
                     $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
                 }
             }

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -16,7 +16,9 @@ class FormUtil
             $value = [];
 
             foreach ($view->children as $child) {
-                $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
+                if ($child->vars['data']) {
+                    $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
+                }
             }
         }
 

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -16,7 +16,7 @@ class FormUtil
             $value = [];
 
             foreach ($view->children as $child) {
-                if (isset($child->vars['checked']) && false === $child->vars['checked']) {
+                if (isset($child->vars['checked'])) {
                     continue;
                 }
 

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -16,7 +16,7 @@ class FormUtil
             $value = [];
 
             foreach ($view->children as $child) {
-                if (null === $child->vars['data']) {
+                if (in_array($child->vars['name'], array_keys($view->vars['value'] ?? []))) {
                     $value[$child->vars['name']] = static::getFormViewValueRecursive($child);
                 }
             }

--- a/tests/Unit/Util/FormUtilTest.php
+++ b/tests/Unit/Util/FormUtilTest.php
@@ -22,15 +22,22 @@ class FormUtilTest extends TestCase
 
     public function testGetFormViewValueRecursiveWithChildren()
     {
+        $from = new \DateTime('2020-01-01');
+        $to = new \DateTime('2020-12-31');
+
         $formViewFrom = new FormView();
         $formViewFrom->vars['name'] = 'from';
-        $formViewFrom->vars['value'] = '2020-01-01';
+        $formViewFrom->vars['value'] = $from->format('Y-m-d');
 
         $formViewTo = new FormView();
         $formViewTo->vars['name'] = 'to';
-        $formViewTo->vars['value'] = '2020-12-31';
+        $formViewTo->vars['value'] = $to->format('Y-m-d');
 
         $formView = new FormView();
+        $formView->vars['value'] = [
+            'from' => $from,
+            'to' => $to,
+        ];
         $formView->children = [
             $formViewFrom->vars['name'] => $formViewFrom,
             $formViewTo->vars['name'] => $formViewTo,

--- a/tests/Unit/Util/FormUtilTest.php
+++ b/tests/Unit/Util/FormUtilTest.php
@@ -22,22 +22,15 @@ class FormUtilTest extends TestCase
 
     public function testGetFormViewValueRecursiveWithChildren()
     {
-        $from = new \DateTime('2020-01-01');
-        $to = new \DateTime('2020-12-31');
-
         $formViewFrom = new FormView();
         $formViewFrom->vars['name'] = 'from';
-        $formViewFrom->vars['value'] = $from->format('Y-m-d');
+        $formViewFrom->vars['value'] = '2020-01-01';
 
         $formViewTo = new FormView();
         $formViewTo->vars['name'] = 'to';
-        $formViewTo->vars['value'] = $to->format('Y-m-d');
+        $formViewTo->vars['value'] = '2020-12-31';
 
         $formView = new FormView();
-        $formView->vars['value'] = [
-            'from' => $from,
-            'to' => $to,
-        ];
         $formView->children = [
             $formViewFrom->vars['name'] => $formViewFrom,
             $formViewTo->vars['name'] => $formViewTo,


### PR DESCRIPTION
Hi @Kreyu,

Here is my second attempt to fix #151. After some more digging I was able to solve this (I hope so) by skipping children with `checked` variable set (in `src/Util/FormUtil.php`). Probably not ideal, but maybe a good starting point?
I also included fix for using other filters when multiple/expanded filter is present (in `src/Filter/FilterData.php`) and fix for clearing multiple/expanded filter (in `src/Filter/FilterClearUrlGenerator.php`). Sorry for trashy commit history.

What do you think about this? If this is not the kind of fix you would like to merge, maybe you have some other idea to solve this?
Today I tested it at my workplace and it looked fine, but of course it needs to be thoroughly tested. @j0r1s could I ask you to test this in your environment?

I also prepared a separate branch in my [demo app](https://github.com/maciazek/kreyu-data-table-bundle-demo) (branch `test/multiple-choices`), where these changes can be tested. After checkout, run `composer install` and `php bin/console app:reload-database`. Filter with multiple/expanded options can be found in Filters -> Doctrine ORM tab.

If anyone would like to test this PR in their app, it can be done in the following way:

- [setup repository in composer.json](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/07796fdbbd7032d49a7163690f577f425dce5dfe/composer.json#L8-L13)
- [change version constraint in composer.json](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/07796fdbbd7032d49a7163690f577f425dce5dfe/composer.json#L23)
- run `composer update kreyu/data-table-bundle` and `php bin/console cache:clear`.