### PR TITLE
Fix some default filters are not included in URL query params

### DIFF
--- a/src/Type/DataTableType.php
+++ b/src/Type/DataTableType.php
@@ -412,7 +412,7 @@ final class DataTableType implements DataTableTypeInterface
                     $value = FormUtil::getFormViewValueRecursive($formView);
                 }
 
-                if (empty($value)) {
+                if (null === $value || '' === $value || [] === $value) {
                     continue;
                 }
 

--- a/src/Util/FormUtil.php
+++ b/src/Util/FormUtil.php
@@ -24,6 +24,6 @@ class FormUtil
             }
         }
 
-        return $value;
+        return empty($value) ? $view->vars['value'] : $value;
     }
 }


### PR DESCRIPTION
Hi,

recently I found some issues when setting up default values for some filters.
After some research I noticed that the problem probably comes from that some of filter types are not appended to URL query parameters when default values are set.

I found problems with two filter types:
- Boolean filter, when set up with false value
- Recently introduced Multiple/Expanded filter

In my [demo app](https://github.com/maciazek/kreyu-data-table-bundle-demo), in Filters -> Doctrine ORM tab, I prepared default filters for testing. For example:

When only boolean(false) filter [has default value set](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/d856630f85af3cb594b405853a5dcf137c11262c/src/DataTable/Type/Filter/FilterDoctrineOrmDataTableType.php#L164), it works correctly. Its value is not appended to URL, but in this case URL does not contain any filter values, so (I assume that) table is using default filtration data.
But when boolean(false) filter default value [is combined with some other filter default value](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/d856630f85af3cb594b405853a5dcf137c11262c/src/DataTable/Type/Filter/FilterDoctrineOrmDataTableType.php#L163-L164), the other filter is appended to URL query, so when we paginate or export, then boolean(false) filter is lost because filtering is based on URL query params and that filter is not appended to URL.
The same situation occurs when we [set default value for boolean(false) filter alone](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/d856630f85af3cb594b405853a5dcf137c11262c/src/DataTable/Type/Filter/FilterDoctrineOrmDataTableType.php#L164), but [there is DateRange filter present among other filters](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/d856630f85af3cb594b405853a5dcf137c11262c/src/DataTable/Type/Filter/FilterDoctrineOrmDataTableType.php#L109-L112). In that case, DateRange filter is ALWAYS appended to URL query (but boolean(false) filter is not) and then boolean(false) filter is lost when paginate/export.

The exact same problem described above happens with [recently introduced multiple/expanded filters](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/d856630f85af3cb594b405853a5dcf137c11262c/src/DataTable/Type/Filter/FilterDoctrineOrmDataTableType.php#L165).

---

So here I would like to propose two changes which aims to fix appending two mentioned filters values to URL query params. What do you think about this?
In my demo app I prepared separate branch (`test/default-filters`), where these fixes can be checked. After checkout, run `composer install` and `php bin/console app:reload-database`
Of course it should be tested thoroughly to make sure it doesn't break anything. Tomorrow I will try to test this at my workplace.

If anyone would like to test this PR in their app, it can be done in the following way:
- [setup repository](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/f046fdc792afaeb7de4210594e5a81b812900937/composer.json#L8-L13) in composer.json
- [change bundle version constraint](https://github.com/maciazek/kreyu-data-table-bundle-demo/blob/f046fdc792afaeb7de4210594e5a81b812900937/composer.json#L23) in composer.json
- run `composer update kreyu/data-table-bundle` and `php bin/console cache:clear`