### PR TITLE
Turbo improvement

### DIFF
--- a/docs/src/docs/features/asynchronicity.md
+++ b/docs/src/docs/features/asynchronicity.md
@@ -36,6 +36,55 @@ If you're making a data table theme from scratch, make sure the table is wrapped
 
 For more information, see [official documentation about the Turbo frames](https://symfony.com/bundles/ux-turbo/current/index.html#decomposing-complex-pages-with-turbo-frames).
 
+## Server-side responses for Turbo Frames
+
+When a request originates from a Turbo Frame, you can return only the HTML of the data table instead of rendering the entire page. This significantly improves performance on pages with lots of content.
+
+This bundle provides a helper for that: the DataTableTurboResponseTrait. It renders just the table's markup so Turbo can replace the content of the requesting frame.
+
+How it works under the hood:
+- The HttpFoundationRequestHandler reads the Turbo-Frame request header and stores it in the DataTable instance.
+- The DataTable::isRequestFromTurboFrame() method returns true when the header matches the table frame id (`kreyu_data_table_<name>`).
+- In that case, you can short-circuit the controller and return only the table HTML using the trait method.
+
+Example controller usage:
+
+```php
+use Kreyu\Bundle\DataTableBundle\DataTableFactoryAwareTrait;
+use Kreyu\Bundle\DataTableBundle\DataTableTurboResponseTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ProductController extends AbstractController
+{
+    use DataTableFactoryAwareTrait;
+    use DataTableTurboResponseTrait;
+
+    public function index(ProductRepository $productRepository, Request $request): Response
+    {
+        $query = $productRepository->createQueryBuilder('product');
+
+        $dataTable = $this->createDataTable(ProductDataTableType::class, $query);
+        $dataTable->handleRequest($request);
+
+        if ($dataTable->isRequestFromTurboFrame()) {
+            // Return only the table's HTML so Turbo can replace the requesting <turbo-frame>
+            return $this->createDataTableTurboResponse($dataTable);
+        }
+
+        // Initial (non-Turbo) request: render the full page
+        return $this->render('home/index.html.twig', [
+            'products' => $dataTable->createView(),
+        ]);
+    }
+}
+```
+
+Notes:
+- Make sure your table is wrapped in a <turbo-frame> as shown above; built-in themes already do this.
+- Turbo sends the Turbo-Frame header with the frame id; the bundle reads it for you. You don't need to access headers directly.
+- The trait requires Twig to be available in your controller service (it is auto-wired by Symfony via the #[Required] setter).
+
 ## Prefetching
 
 <TurboPrefetchingSection>

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -112,6 +112,7 @@ class DataTable implements DataTableInterface
     private ?ResultSetInterface $resultSet = null;
 
     private bool $initialized = false;
+    private ?string $turboFrameId = null;
 
     public function __construct(
         private ProxyQueryInterface $query,
@@ -865,6 +866,17 @@ class DataTable implements DataTableInterface
         $type->buildExportView($view, $this, $options);
 
         return $view;
+    }
+
+    public function setTurboFrameId(?string $turboFrameId): static
+    {
+        $this->turboFrameId = $turboFrameId;
+        return $this;
+    }
+
+    public function isRequestFromTurboFrame(): bool
+    {
+        return null !== $this->turboFrameId && 'kreyu_data_table_'.$this->getName() === $this->turboFrameId;
     }
 
     private function dispatch(string $eventName, DataTableEvent $event): void

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -871,6 +871,7 @@ class DataTable implements DataTableInterface
     public function setTurboFrameId(?string $turboFrameId): static
     {
         $this->turboFrameId = $turboFrameId;
+
         return $this;
     }
 

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -215,4 +215,5 @@ interface DataTableInterface
     public function createView(): DataTableView;
 
     public function createExportView(): DataTableView;
+    public function setTurboFrameId(string $turboFrameId): static;
 }

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -217,5 +217,6 @@ interface DataTableInterface
     public function createExportView(): DataTableView;
 
     public function setTurboFrameId(string $turboFrameId): static;
+
     public function isRequestFromTurboFrame(): bool;
 }

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -217,4 +217,5 @@ interface DataTableInterface
     public function createExportView(): DataTableView;
 
     public function setTurboFrameId(string $turboFrameId): static;
+    public function isRequestFromTurboFrame(): bool;
 }

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -215,5 +215,6 @@ interface DataTableInterface
     public function createView(): DataTableView;
 
     public function createExportView(): DataTableView;
+
     public function setTurboFrameId(string $turboFrameId): static;
 }

--- a/src/DataTableTurboResponseTrait.php
+++ b/src/DataTableTurboResponseTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreyu\Bundle\DataTableBundle;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
+use Twig\Environment;
+
+trait DataTableTurboResponseTrait
+{
+    protected ?Environment $twig = null;
+
+    #[Required]
+    public function setTwig(?Environment $twig): void
+    {
+        $this->twig = $twig;
+    }
+
+    public function createDataTableTurboResponse(
+        DataTableInterface $dataTable,
+    ): Response {
+        return new Response(
+            $this->twig->createTemplate('{{ data_table(dataTableContent) }}')->render([
+                'dataTableContent' => $dataTable->createView(),
+            ]),
+        );
+    }
+}

--- a/src/Request/HttpFoundationRequestHandler.php
+++ b/src/Request/HttpFoundationRequestHandler.php
@@ -37,6 +37,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
         $this->personalize($dataTable, $request);
         $this->paginate($dataTable, $request);
         $this->export($dataTable, $request);
+        $this->turbo($dataTable, $request);
     }
 
     private function filter(DataTableInterface $dataTable, Request $request): void
@@ -133,5 +134,10 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
     private function extractQueryParameter(Request $request, string $path): mixed
     {
         return $this->propertyAccessor->getValue($request->query->all(), $path);
+    }
+
+    private function turbo(DataTableInterface $dataTable, Request $request): void
+    {
+        $dataTable->setTurboFrameId($request->headers->get('Turbo-Frame'));
     }
 }


### PR DESCRIPTION
# Context / Problem

- Content-heavy pages with multiple tables often trigger full page reloads, even when a Turbo Frame only requires a fragment of HTML.
- Existing docs covered the Turbo integration (wrapping in <turbo-frame>) but didn’t explain how to respond server-side with only the table’s HTML.

## Solution
- Documentation: added a new section “Server-side responses for Turbo Frames” in docs/src/docs/features/asynchronicity.md.
- The section explains:
    - Concept: if the request comes from a Turbo Frame, return only the table markup;
    - Internals: HttpFoundationRequestHandler reads the Turbo-Frame header, stores it in the DataTable instance, and DataTable::isRequestFromTurboFrame() checks it;
    - Controller usage: use DataTableTurboResponseTrait and short-circuit the full-page render.
- Includes a concrete Symfony controller example.

## Example

```php
use Kreyu\Bundle\DataTableBundle\DataTableFactoryAwareTrait;
use Kreyu\Bundle\DataTableBundle\DataTableTurboResponseTrait;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\Response;

class ProductController extends AbstractController
{
    use DataTableFactoryAwareTrait;
    use DataTableTurboResponseTrait;

    public function index(ProductRepository $productRepository, Request $request): Response
    {
        $query = $productRepository->createQueryBuilder('product');

        $dataTable = $this->createDataTable(ProductDataTableType::class, $query);
        $dataTable->handleRequest($request);

        if ($dataTable->isRequestFromTurboFrame()) {
            // Return only the table's HTML so Turbo can replace the requesting <turbo-frame>
            return $this->createDataTableTurboResponse($dataTable);
        }

        // Initial (non-Turbo) request: render the full page
        return $this->render('home/index.html.twig', [
            'products' => $dataTable->createView(),
        ]);
    }
}
```

What do you think about it ?