### PR TITLE
Use closures instead of callables in options

### DIFF
--- a/docs/src/docs/components/actions.md
+++ b/docs/src/docs/components/actions.md
@@ -22,8 +22,8 @@ This kind of action can be used, for example, for "Update" button that redirects
 
 **Batch actions**
 
-Actions that are bound to a multiple rows, selected by a checkbox column. 
-Batch actions require `batch` Stimulus controller enabled: 
+Actions that are bound to a multiple rows, selected by a checkbox column.
+Batch actions require `batch` Stimulus controller enabled:
 
 ```json5
 // assets/controllers.json
@@ -56,11 +56,11 @@ class ProductDataTableType extends AbstractDataTableType
             ->addAction('create', ButtonActionType::class, [
                 'href' => $this->urlGenerator->generate('app_product_create'),
             ])
-            // note that row action has access to a row data in a callable
+            // note that row action has access to a row data in a closure
             ->addRowAction('update', ButtonActionType::class, [
                 'href' => function (Product $product) {
                     return $this->urlGenerator->generate('app_product_update', [
-                        'id' => $product->getId(),                
+                        'id' => $product->getId(),
                     ]);
                 }
             ])
@@ -82,7 +82,7 @@ For reference, see [available action types](../../reference/types/action.md).
 
 ## Creating action types
 
-If built-in action types are not enough, you can create your own. In following chapters, we'll be creating an action that opens a modal. 
+If built-in action types are not enough, you can create your own. In following chapters, we'll be creating an action that opens a modal.
 
 Action types are classes that implement [ActionTypeInterface](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/ActionTypeInterface.php), although, it is recommended to extend from the [AbstractActionType](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/AbstractActionType.php) class:
 
@@ -119,7 +119,7 @@ class ModalActionType extends AbstractActionType
 ```
 
 ::: tip
-If you take a look at the [`AbstractActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/AbstractActionType.php), 
+If you take a look at the [`AbstractActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/AbstractActionType.php),
 you'll see that `getParent()` method returns fully-qualified name of the [`ActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/ActionType.php) type class.
 This is the type that defines all the basic options, such as `attr`, `label`, etc.
 :::
@@ -138,7 +138,7 @@ First, create a custom theme for the data table, and create a `action_modal_valu
     <button class="btn btn-primary" data-bs-toggle="modal", data-bs-target="#action-modal-{{ name }}">
         {{ label }}
     </button>
-    
+
     <div class="modal fade" id="#action-modal-{{ name }}">
         {# Bootstrap modal contents... #}
     </div>
@@ -261,7 +261,7 @@ Now we can update the template of the type class to use the newly added variable
     <button class="btn btn-primary" data-bs-toggle="modal", data-bs-target="#action-modal-{{ name }}">
         {{ label }}
     </button>
-    
+
     <div class="modal fade" id="action-modal-{{ name }}">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -277,32 +277,32 @@ Now we can update the template of the type class to use the newly added variable
 > What if I want to pass an option based on the row data?
 
 If the action type is used for a row action, the `ActionView` parent will be an instance of `ColumnValueView`,
-which can be used to retrieve a data of the row. This can be used in combination with accepting the `callable` options:
+which can be used to retrieve a data of the row. This can be used in combination with accepting the closure options:
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Action\Type\ButtonActionType;
 use Kreyu\Bundle\DataTableBundle\Action\ActionView;
 use Kreyu\Bundle\DataTableBundle\Action\ActionInterface;
-use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView; // [!code ++] 
+use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView; // [!code ++]
 
 class ModalActionType extends ButtonActionType
 {
     public function buildView(ActionView $view, ActionInterface $action, array $options): void
     {
-        if ($view->parent instanceof ColumnValueView) { // [!code ++] 
-            $value = $view->parent->vars['value']; // [!code ++] 
+        if ($view->parent instanceof ColumnValueView) { // [!code ++]
+            $value = $view->parent->vars['value']; // [!code ++]
 
-            foreach (['template_path', 'template_vars'] as $optionName) { // [!code ++] 
-                if (is_callable($options[$optionName])) { // [!code ++] 
-                    $options[$optionName] = $options[$optionName]($value); // [!code ++] 
+            foreach (['template_path', 'template_vars'] as $optionName) { // [!code ++]
+                if ($options[$optionName] instanceof \Closure) { // [!code ++]
+                    $options[$optionName] = $options[$optionName]($value); // [!code ++]
                 } // [!code ++]
             } // [!code ++]
         } // [!code ++]
-    
+
         $view->vars['template_path'] = $options['template_path'];
         $view->vars['template_vars'] = $options['template_vars'];
     }
-    
+
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -314,15 +314,15 @@ class ModalActionType extends ButtonActionType
             ])
             // optionally you can restrict type of the options
             ->setAllowedTypes('template_path', 'string') // [!code --]
-            ->setAllowedTypes('template_path', ['string', 'callable']) // [!code ++]
+            ->setAllowedTypes('template_path', ['string', \Closure::class// [!code ++]
             ->setAllowedTypes('template_vars', 'array') // [!code --]
-            ->setAllowedTypes('template_vars', ['array', 'callable']) // [!code ++]
+            ->setAllowedTypes('template_vars', ['array', \Closure::class]) // [!code ++]
         ;
     }
 }
 ```
 
-Now, you can use the `callable` options when defining the modal row action: 
+Now, you can pass the options as closure when defining the modal row action:
 
 ```php
 class UserDataTableType extends AbstractDataTableType
@@ -364,13 +364,13 @@ class TooltipActionTypeExtension extends AbstractActionTypeExtension
         if (!$options['tooltip']) {
             return;
         }
-        
+
         $title = $view->vars['attr']['title'] ?? null;
-        
+
         if (empty($title)) {
             return;
         }
-        
+
         $view->vars['attr']['data-bs-toggle'] = 'tooltip';
         $view->vars['attr']['data-bs-placement'] = 'top';
         $view->vars['attr']['data-bs-title'] = $title;
@@ -383,7 +383,7 @@ class TooltipActionTypeExtension extends AbstractActionTypeExtension
             ->setAllowedTypes('tooltip', 'bool')
         ;
     }
-    
+
     public static function getExtendedTypes(): iterable
     {
         return [ButtonActionType::class];
@@ -611,7 +611,7 @@ You can define an action to open a modal with contents loaded from given URL.
 For example, let's define a modal that displays a post details.
 
 First things first, the built-in modal action type requires additional JavaScript to work properly.
-If using the built-in Bootstrap 5 or Tabler (based on Bootstrap) theme, we have to enable the `bootstrap-modal` 
+If using the built-in Bootstrap 5 or Tabler (based on Bootstrap) theme, we have to enable the `bootstrap-modal`
 script in your `controllers.json` file, because **it is disabled by default**:
 
 ```json
@@ -783,14 +783,14 @@ There are multiple ways to support the variants, however, this is how built-in t
         danger: 'btn-danger',
         primary: 'btn-primary',
     }|merge(variants ?? {})|filter(e => e is not same as false) -%}
-    
+
     {% set base_classes = base_classes ?? 'btn' %}
     {% set variant_classes = variant_classes ?? variants[variant ?? default_variant ?? 'primary'] %}
-    
-    {% set attr = attr|merge({ 
-        class: (base_classes ~ ' ' ~ variant_classes ~ ' ' ~ attr.class|default(''))|trim 
+
+    {% set attr = attr|merge({
+        class: (base_classes ~ ' ' ~ variant_classes ~ ' ' ~ attr.class|default(''))|trim
     }) %}
-    
+
     {# ... #}
 {%- block action_button_control %}
 ```
@@ -840,7 +840,7 @@ To achieve this, override the action block and provide `default_variant` variabl
 {%- block button_action_control %}
 ```
 
-Default variant is applied when the `variant` variable is set to `null` - for example, if `variant` option is not given. 
+Default variant is applied when the `variant` variable is set to `null` - for example, if `variant` option is not given.
 
 ## Prefetching
 

--- a/docs/src/reference/types/action/button.md
+++ b/docs/src/reference/types/action/button.md
@@ -28,7 +28,7 @@ $builder->addRowAction('show', ButtonActionType::class, [
 
 ### `href`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'#'`
 
 A value used as an action link [href attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href).
@@ -45,7 +45,7 @@ $builder
 
 ### `target`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'_self'`
 
 Sets the value that will be used as an anchor [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).

--- a/docs/src/reference/types/action/dropdown.md
+++ b/docs/src/reference/types/action/dropdown.md
@@ -10,7 +10,7 @@ The [`DropdownActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/
 
 ### `actions`
 
-- **type**: `array` or `callable` (if using as a row action)
+- **type**: `array` or `\Closure` (if using as a row action)
 
 An array of actions that will be rendered as dropdown items.
 Each action can be created using `createAction`, `createRowAction` or `createBatchAction` method, depending on the context:
@@ -23,7 +23,7 @@ $builder
     ->addAction('advanced', DropdownActionType::class, [
         'actions' => [
             $builder->createAction('update', LinkDropdownItemActionType::class, [
-                'href' => '#'            
+                'href' => '#'
             ]),
         ],
     ])
@@ -33,7 +33,7 @@ $builder
 While theoretically you _can_ use wrong method for dropdown items, e.g. `createBatchAction` for a dropdown action created by `addRowAction`,
 the bundle will automatically change the context of the action to the proper one. However, try to use proper methods for better readability.
 
-When using the `DropdownActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `DropdownActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return an array of actions.
 
 ```php
@@ -70,7 +70,7 @@ Whether to render a caret icon next to the dropdown label. For example:
 ```php
 use Kreyu\Bundle\DataTableBundle\Action\Type\Dropdown\DropdownActionType;
 
-$builder 
+$builder
     ->addRowAction('dropdownWithCaret', DropdownActionType::class, [
         'label' => 'Dropdown with caret',
         'with_caret' => true,

--- a/docs/src/reference/types/action/form.md
+++ b/docs/src/reference/types/action/form.md
@@ -4,13 +4,13 @@
 
 # FormActionType
 
-The [`FormActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/FormActionType.php) represents an action rendered as a submit button to a hidden form, which allows the action to use any HTTP method. 
+The [`FormActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/FormActionType.php) represents an action rendered as a submit button to a hidden form, which allows the action to use any HTTP method.
 
 ## Options
 
 ### `action`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'#'`
 
 Sets the value that will be used as a form's `action` attribute.
@@ -27,7 +27,7 @@ $builder
 
 ### `method`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'GET'`
 
 Sets the value that will be used as a form's `method` attribute.
@@ -44,7 +44,7 @@ $builder
 
 ### `button_attr`
 
-- **type**: `array` or `callable`
+- **type**: `array` or `\Closure`
 - **default**: `[]`
 
 An array of attributes used to render the form submit button.

--- a/docs/src/reference/types/action/link-dropdown-item.md
+++ b/docs/src/reference/types/action/link-dropdown-item.md
@@ -5,7 +5,7 @@
 
 # LinkDropdownItemActionType
 
-The [`LinkDropdownItemActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/Dropdown/LinkDropdownItemActionType.php) 
+The [`LinkDropdownItemActionType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/Action/Type/Dropdown/LinkDropdownItemActionType.php)
 represents an action rendered as dropdown item with a simple link.  It is meant to be used as a child of the [`DropdownActionType`](dropdown.md).
 
 ## Prefetching
@@ -36,7 +36,7 @@ $builder
 
 ### `href`
 
-- **type**: `string` or `callable` (if using as a row action)
+- **type**: `string` or `\Closure` (if using as a row action)
 - **default**: `'#'`
 
 A value used as an action link [href attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href).
@@ -49,14 +49,14 @@ $builder
     ->addAction('advanced', DropdownActionType::class, [
         'actions' => [
             $builder->createAction('update', LinkDropdownItemActionType::class, [
-                'href' => '#',           
+                'href' => '#',
             ]),
         ],
     ])
 ;
 ```
 
-When using the `LinkDropdownItemActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `LinkDropdownItemActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return an array of actions.
 
 ```php
@@ -80,7 +80,7 @@ $builder
 
 ### `target`
 
-- **type**: `string` or `callable` (if using as a row action)
+- **type**: `string` or `\Closure` (if using as a row action)
 - **default**: `'_self'`
 
 Sets the value that will be used as an anchor [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).
@@ -101,7 +101,7 @@ $builder
 ;
 ```
 
-When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string.
 
 ```php
@@ -118,7 +118,7 @@ $builder
             ])
         ],
     ])
-    
+
 ;
 ```
 

--- a/docs/src/reference/types/action/link.md
+++ b/docs/src/reference/types/action/link.md
@@ -28,7 +28,7 @@ $builder->addRowAction('show', LinkActionType::class, [
 
 ### `href`
 
-- **type**: `string` or `callable` (if using as a row action)
+- **type**: `string` or `\Closure` (if using as a row action)
 - **default**: `'#'`
 
 A value used as an action link [href attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href).
@@ -43,7 +43,7 @@ $builder
 ;
 ```
 
-When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string.
 
 ```php
@@ -53,7 +53,7 @@ $builder
     ->addAction('back', LinkActionType::class, [
         'href' => function (Category $category) {
             return $this->urlGenerator->generate('category_index', [
-                'id' => $category->getId(),        
+                'id' => $category->getId(),
             ]);
         },
     ])
@@ -62,7 +62,7 @@ $builder
 
 ### `target`
 
-- **type**: `string` or `callable` (if using as a row action)
+- **type**: `string` or `\Closure` (if using as a row action)
 - **default**: `'_self'`
 
 Sets the value that will be used as an anchor [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).
@@ -77,7 +77,7 @@ $builder
 ;
 ```
 
-When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `LinkActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string.
 
 ```php

--- a/docs/src/reference/types/action/modal.md
+++ b/docs/src/reference/types/action/modal.md
@@ -10,7 +10,7 @@ that opens a modal dialog with contents loaded from given URL.
 > [!WARNING]
 > This action type requires additional JavaScript to work properly. If using the built-in Bootstrap 5 or Tabler (based on Bootstrap) theme,
 > enable the `bootstrap-modal` script in your `controllers.json` file, because **it is disabled by default**.
-> 
+>
 > ```json
 > {
 >   "controllers": {
@@ -27,7 +27,7 @@ that opens a modal dialog with contents loaded from given URL.
 
 ### `href`
 
-- **type**: `null`, `string` or `callable` (if using as a row action)
+- **type**: `null`, `string` or `\Closure` (if using as a row action)
 - **default**: `null`
 
 A URL to load the modal contents from. Can be used instead of [`route`](#route) and [`route_params`](#route_params) options,
@@ -43,7 +43,7 @@ $builder
 ;
 ```
 
-When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a URL.
 
 ```php
@@ -66,7 +66,7 @@ $builder
 
 ### `route`
 
-- **type**: `null`, `string` or `callable` (if using as a row action)
+- **type**: `null`, `string` or `\Closure` (if using as a row action)
 - **default**: `null`
 
 A route name to generate the URL from. Can be used instead of [`href`](#href) option.
@@ -81,7 +81,7 @@ $builder
 ;
 ```
 
-When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a route name.
 
 ```php
@@ -98,7 +98,7 @@ $builder
 
 ### `route_params`
 
-- **type**: `array` or `callable` (if using as a row action)
+- **type**: `array` or `\Closure` (if using as a row action)
 - **default**: `[]`
 
 A route params passed to the route provided in [`route`](#route) option. Can be used instead of [`href`](#href) option.
@@ -116,7 +116,7 @@ $builder
 ;
 ```
 
-When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a callable
+When using the `ModalActionType` as a [row action](../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a route params array.
 
 ```php

--- a/docs/src/reference/types/action/options/action.md
+++ b/docs/src/reference/types/action/options/action.md
@@ -36,12 +36,12 @@ the rendering of some of them, without the need to create a new action type.
 
 ### `visible`
 
-- **type**: `bool` or `callable`
+- **type**: `bool` or `\Closure`
 - **default**: `true`
 
 Determines whether the action should be visible to the user.
 
-The callable can only be used by the row actions to determine visibility [based on the row data](../../../../docs/components/actions.md#using-row-data-in-options):
+The closure can only be used by the row actions to determine visibility [based on the row data](../../../../docs/components/actions.md#using-row-data-in-options):
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Action\Type\ButtonActionType;
@@ -77,7 +77,7 @@ $builder
 
 ### `icon`
 
-- **type**: `null`, `string` or `callable`
+- **type**: `null`, `string` or `\Closure`
 - **default**: `null`
 
 Defines the icon to render.
@@ -96,7 +96,7 @@ $builder
 > Name of the icon depends on the icon set you are using in the application,
 > and which icon theme is configured for the data table. See the [icon themes documentation section](./../../../../docs/features/theming.md#icon-themes) for more information.
 
-When action is a [row action](./../../../../docs/components/actions.md), you can provide a callable
+When action is a [row action](./../../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string:
 
 ```php
@@ -111,7 +111,7 @@ $builder
 
 ### `icon_attr`
 
-- **type**: `array` or `callable`
+- **type**: `array` or `\Closure`
 - **default**: `[]`
 
 Defines the HTML attributes for the icon to render.
@@ -129,7 +129,7 @@ $builder
 ;
 ```
 
-When action is a [row action](../../../../docs/components/actions.md), you can provide a callable
+When action is a [row action](../../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string:
 
 ```php
@@ -139,7 +139,7 @@ $builder
     ->addRowAction('toggle', ButtonActionType::class, [
         'icon' => fn (User $user) => $user->isActive() ? 'unlock' : 'lock',
         'icon_attr' => fn (User $user) => [
-            'class' => $user->isActive() ? 'text-danger' : 'text-success',        
+            'class' => $user->isActive() ? 'text-danger' : 'text-success',
         ],
     ])
 ;
@@ -147,7 +147,7 @@ $builder
 
 ### `variant`
 
-- **type**: `null`, `string` or `callable`
+- **type**: `null`, `string` or `\Closure`
 - **default**: `null`
 
 Defines the variant of the action. The action will be rendered differently in each variant.
@@ -162,7 +162,7 @@ $builder
 ;
 ```
 
-When action is a [row action](../../../../docs/components/actions.md), you can provide a callable
+When action is a [row action](../../../../docs/components/actions.md), you can provide a closure
 that will receive the row data as an argument and should return a string:
 
 ```php
@@ -181,41 +181,41 @@ For more details, see [documentation about action variants](../../../../docs/com
 
 ### `confirmation`
 
-- **type**: `bool`, `array` or `callable`
+- **type**: `bool`, `array` or `\Closure`
 - **default**: `false`
 
 Determines whether the action is confirmable, which displays a modal where user have to acknowledge the process.
 The modal can be configured by passing an array with the following options:
 
 > #### `translation_domain`
-> 
+>
 > - **type**: `false` or `string`
 > - **default**: `'KreyuDataTable'`
-> 
+>
 > #### `label_title`
-> 
+>
 > - **type**: `null` or `string`
 > - **default**: `'Action confirmation'`
-> 
+>
 > #### `label_description`
-> 
+>
 > - **type**: `null` or `string`
 > - **default**: `'Are you sure you want to execute this action?'`
-> 
+>
 > #### `label_confirm`
-> 
+>
 > - **type**: `null` or `string`
 > - **default**: `'Confirm'`
-> 
+>
 > #### `label_cancel`
-> 
+>
 > - **type**: `null` or `string`
 > - **default**: `'Cancel'`
-> 
+>
 > #### `type`
-> 
+>
 > - **type**: `null` or `string`
 > - **default**: `danger`
 > - **allowed values**: `danger`, `warning`, `info`
-> 
+>
 > Represents a type of the action confirmation, which determines the color of the displayed modal.

--- a/docs/src/reference/types/column/actions.md
+++ b/docs/src/reference/types/column/actions.md
@@ -21,23 +21,23 @@ If at least one row action is defined and is visible, an `ActionColumnType` is a
 This option contains a list of actions. Each action consists of _three_ options:
 
 > #### `type`
-> 
+>
 > - **type**: `string`
-> 
+>
 > Fully qualified class name of the [action type](#).
 > <br/><br/>
-> 
+>
 > #### `type_options`
-> 
+>
 > - **type**: `array`
-> - **default**: `[]`  
-> 
+> - **default**: `[]`
+>
 > Options passed to the action type.
 > <br/><br/>
-> 
+>
 > #### `visible`
-> 
-> - **type**: `bool`or `callable`
+>
+> - **type**: `bool`or `\Closure`
 > - **default**: `true`
 
 Determines whether the action should be visible.
@@ -58,7 +58,7 @@ $builder
                         return $this->urlGenerator->generate('category_show', [
                             'id' => $product->getId(),
                         ]);
-                    }),                
+                    }),
                 ],
                 'visible' => function (Product $product): bool {
                     return $product->isActive();

--- a/docs/src/reference/types/column/enum.md
+++ b/docs/src/reference/types/column/enum.md
@@ -10,8 +10,8 @@ The [`EnumColumnType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/
 
 ### `formatter`
 
-- **type**: `null` or `callable`
-- **default**: callable that translates the enum if possible
+- **type**: `null` or `\Closure`
+- **default**: closure that translates the enum if possible
 
 Formats the enum value. If Symfony Translator component is available, and the enum implements [`TranslatableInterface`](https://github.com/symfony/translation-contracts/blob/main/TranslatableInterface.php),
 the enum will be translated. Otherwise, the enum name will be displayed.

--- a/docs/src/reference/types/column/icon.md
+++ b/docs/src/reference/types/column/icon.md
@@ -10,7 +10,7 @@ The [`IconColumnType`](https://github.com/Kreyu/data-table-bundle/blob/main/src/
 
 ### `icon`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 
 Defines the icon to render.
 
@@ -25,10 +25,10 @@ $builder
 ```
 
 > [!TIP] Wondering how does the icon gets rendered?
-> Name of the icon depends on the icon set you are using in the application, 
-> and which icon theme is configured for the data table. See the [icon themes documentation section](./../../../docs/features/theming.md#icon-themes) for more information. 
+> Name of the icon depends on the icon set you are using in the application,
+> and which icon theme is configured for the data table. See the [icon themes documentation section](./../../../docs/features/theming.md#icon-themes) for more information.
 
-You can provide a callable that will receive a column value as an argument:
+You can provide a closure that will receive a column value as an argument:
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Column\Type\IconColumnType;
@@ -45,7 +45,7 @@ $builder
 
 ### `icon_attr`
 
-- **type**: `array` or `callable`
+- **type**: `array` or `\Closure`
 - **default**: `[]`
 
 Defines the HTML attributes for the icon to render.
@@ -63,7 +63,7 @@ $builder
 ;
 ```
 
-You can provide a callable that will receive a column value as an argument:
+You can provide a closure that will receive a column value as an argument:
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Column\Type\IconColumnType;
@@ -78,7 +78,7 @@ $builder
             'class' => match ($status) {
                 'draft' => 'text-warning',
                 'completed' => 'text-success',
-            },        
+            },
         ],
     ])
 ;

--- a/docs/src/reference/types/column/link.md
+++ b/docs/src/reference/types/column/link.md
@@ -29,7 +29,7 @@ $builder->addColumn('show', LinkColumnType::class, [
 
 ### `href`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'#'`
 
 Sets the value that will be used as a [href attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href).
@@ -62,11 +62,11 @@ $builder
 
 ### `target`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 - **default**: `'_self'`
 
-Sets the value that will be used as a [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target). 
-Similar to [`href`](#href) option, you can pass a callable that receives three arguments.
+Sets the value that will be used as a [target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).
+Similar to [`href`](#href) option, you can pass a closure that receives three arguments.
 
 ## Inherited options
 

--- a/docs/src/reference/types/column/money.md
+++ b/docs/src/reference/types/column/money.md
@@ -10,25 +10,25 @@ The [`MoneyColumnType`](https://github.com/Kreyu/data-table-bundle/blob/main/src
 
 ### `currency`
 
-- **type**: `string` or `callable` - any [3-letter ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217) 
+- **type**: `string` or `\Closure` - any [3-letter ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217)
 
-Specifies the currency that the money is being specified in. 
+Specifies the currency that the money is being specified in.
 This determines the currency symbol that should be shown in the column.
 
-When using the [Intl number formatter](https://www.php.net/manual/en/class.numberformatter.php), 
+When using the [Intl number formatter](https://www.php.net/manual/en/class.numberformatter.php),
 the ISO code will be automatically converted to the appropriate currency sign, for example:
 
 - `EUR` becomes `€`;
 - `PLN` becomes `zł`;
 
-Please note that the end result is also dependent on the locale used in the application, for example, with value of `1000`: 
+Please note that the end result is also dependent on the locale used in the application, for example, with value of `1000`:
 
 - `USD` currency will be rendered as `$1,000.00` when using the `en` locale;
 - `USD` currency will be rendered as `1 000,00 USD` when using the `pl` locale;
 
 When the Intl formatter is **NOT** used, given currency is simply rendered after the raw value, e.g. `1000 USD`.
 
-Additionally, the option accepts a callable, which gets a row data as first argument:
+Additionally, the option accepts a closure, which gets a row data as first argument:
 
 ```php
 $builder
@@ -43,8 +43,8 @@ $builder
 - **type**: `integer`
 - **default**: `1`
 
-If you need to divide your starting value by a number before rendering it to the user, 
-you can use the `divisor` option. For example if you need to show amounts as integer in order to avoid 
+If you need to divide your starting value by a number before rendering it to the user,
+you can use the `divisor` option. For example if you need to show amounts as integer in order to avoid
 rounding errors, you can transform values in cents automatically:
 
 ```php

--- a/docs/src/reference/types/column/options/column.md
+++ b/docs/src/reference/types/column/options/column.md
@@ -17,7 +17,7 @@ const props = defineProps({
 ### `label`
 
 - **type**: `null`, `string` or `Symfony\Component\Translation\TranslatableInterface`
-- **default**: `{{ defaults.label }}` 
+- **default**: `{{ defaults.label }}`
 
 Sets the label that will be used in column header and personalization column list.
 
@@ -33,7 +33,7 @@ When value equals `null`, a sentence cased column name is used as a label, for e
 - **type**: `false` or `string`
 - **default**: `'KreyuDataTable'`
 
-Sets the translation domain used when translating the column header.  
+Sets the translation domain used when translating the column header.
 Setting the option to `false` disables its translation.
 
 ### `header_translation_parameters`
@@ -69,17 +69,17 @@ For more details, see [translating column values](../../../../docs/components/co
 - **type**: `false` or `string`
 - **default**: inherited from the data table translation domain
 
-Sets the translation domain used when translating the column value.  
+Sets the translation domain used when translating the column value.
 Setting the option to `false` disables its translation.
 
 ### `value_translation_parameters`
 
-- **type**: `array` or `callable` that returns an array
+- **type**: `array` or `\Closure` that returns an array
 - **default**: `[]`
 
 Sets the parameters used when translating the column value.
 
-If given the callable, it will receive two arguments:
+If given the closure, it will receive two arguments:
 - column value, e.g. column (row) data formatted by the optional `formatter` option;
 - column (row) data, e.g. value returned by property accessor or getter;
 
@@ -92,14 +92,14 @@ $builder->addColumn('firstName', options: [
 ]);
 ```
 
-The `ColumnValueView` will contain the resolved callable.
+The `ColumnValueView` will contain the resolved closure.
 
 ### `property_path`
 
 - **type**: `null`, `false` or `string`
 - **default**: `{{ defaults.property_path }}`
 
-Sets the property path used by the [PropertyAccessor](https://symfony.com/doc/current/components/property_access.html) to retrieve column value of each row.  
+Sets the property path used by the [PropertyAccessor](https://symfony.com/doc/current/components/property_access.html) to retrieve column value of each row.
 Setting the option to `false` disables property accessor.
 
 ```php
@@ -114,10 +114,10 @@ When value equals `null`, the column name is used as a property path.
 
 ### `getter`
 
-- **type**: `null` or `callable`
+- **type**: `null` or `\Closure`
 - **default**: `null`
 
-When provided, this callable will be invoked to read the value from the underlying object that will be used within the column.
+When provided, this closure will be invoked to read the value from the underlying object that will be used within the column.
 This disables the usage of the [PropertyAccessor](https://symfony.com/doc/current/components/property_access.html), described in the [property_path](#property_path) option.
 
 ```php
@@ -151,7 +151,7 @@ the rendering of some of them, without the need to create a new column type.
 
 ### `formatter`
 
-- **type**: `null` or `callable`
+- **type**: `null` or `\Closure`
 - **default**: `null`
 
 Formats the value to the desired string.
@@ -193,7 +193,7 @@ $builder
 
 Rest of the options are inherited from the column options.
 
-Setting this option to `true` automatically copies the column options as the export column options.  
+Setting this option to `true` automatically copies the column options as the export column options.
 Setting this option to `false` excludes the column from the exports.
 
 ### `header_attr`
@@ -217,7 +217,7 @@ $builder
 
 ### `value_attr`
 
-- **type**: `array` or `callable`
+- **type**: `array` or `\Closure`
 - **default**: `[]`
 
 If you want to add extra attributes to an HTML column value representation (`<td>`) you can use the attr option.
@@ -234,7 +234,7 @@ $builder
 ;
 ```
 
-You can pass a `callable` to perform a dynamic attribute generation:
+You can pass a `\Closure` to perform a dynamic attribute generation:
 
 ```php
 $builder
@@ -246,7 +246,7 @@ $builder
         },
     ])
 ;
-``` 
+```
 
 ### `priority`
 

--- a/docs/src/reference/types/column/template.md
+++ b/docs/src/reference/types/column/template.md
@@ -10,13 +10,13 @@ The [`TemplateColumnType`](https://github.com/Kreyu/data-table-bundle/blob/main/
 
 ### `template_path`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 
 Sets the path to the template that should be rendered.
 
 ### `template_vars`
 
-- **type**: `string` or `callable`
+- **type**: `string` or `\Closure`
 
 Sets the variables used within the template.
 

--- a/docs/src/reference/types/exporter/callback.md
+++ b/docs/src/reference/types/exporter/callback.md
@@ -10,9 +10,9 @@ The [`CallbackExporterType`](https://github.com/Kreyu/data-table-bundle/blob/mai
 
 ### `callback`
 
-- **type**: `callable`
+- **type**: `\Closure`
 
-Sets callable that works as an exporter handler.
+Sets closure that works as an exporter handler.
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Exporter\Type\CallbackExporterType;

--- a/docs/src/reference/types/exporter/php-spreadsheet/html.md
+++ b/docs/src/reference/types/exporter/php-spreadsheet/html.md
@@ -70,7 +70,7 @@ Determines whether the sheet navigation block should be generated or not.
 
 ### `edit_html_callback`
 
-- **type**: `null` or `callable`
+- **type**: `null` or `\Closure`
 - **default**: `null`
 
 Accepts a callback function to edit the generated html before saving.
@@ -87,7 +87,7 @@ $builder
                 '{border: 2px dashed red;}',
                 $html,
             );
-        } 
+        }
     ])
 ;
 ```

--- a/docs/src/reference/types/exporter/php-spreadsheet/pdf.md
+++ b/docs/src/reference/types/exporter/php-spreadsheet/pdf.md
@@ -70,7 +70,7 @@ Determines whether the sheet navigation block should be generated or not.
 
 ### `edit_html_callback`
 
-- **type**: `null` or `callable`
+- **type**: `null` or `\Closure`
 - **default**: `null`
 
 Accepts a callback function to edit the generated html before saving.
@@ -87,7 +87,7 @@ $builder
                 '{border: 2px dashed red;}',
                 $html,
             );
-        } 
+        }
     ])
 ;
 ```

--- a/docs/src/reference/types/filter/callback.md
+++ b/docs/src/reference/types/filter/callback.md
@@ -10,9 +10,9 @@ The [`CallbackFilterType`](https://github.com/Kreyu/data-table-bundle/blob/main/
 
 ### `callback`
 
-- **type**: `callable`
+- **type**: `\Closure`
 
-Sets callable that works as a filter handler.
+Sets closure that works as a filter handler.
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Filter\Type\CallbackFilterType;

--- a/docs/src/reference/types/filter/search.md
+++ b/docs/src/reference/types/filter/search.md
@@ -28,9 +28,9 @@ class ProductDataTableType extends AbstractDataTableType
 }
 ```
 
-Defining a search handler automatically adds search filter. 
+Defining a search handler automatically adds search filter.
 
-To disable this behavior, use the `setAutoAddingSearchFilter()` method: 
+To disable this behavior, use the `setAutoAddingSearchFilter()` method:
 
 ```php
 use Kreyu\Bundle\DataTableBundle\DataTableBuilderInterface;
@@ -70,9 +70,9 @@ class ProductDataTableType extends AbstractDataTableType
 
 ### `handler`
 
-- **type**: `callable`
+- **type**: `\Closure`
 
-Sets callable that operates on the query passed as a first argument:
+Sets closure that operates on the query passed as a first argument:
 
 ```php
 use Kreyu\Bundle\DataTableBundle\Filter\Type\SearchFilterType;

--- a/src/Action/Type/ActionType.php
+++ b/src/Action/Type/ActionType.php
@@ -27,7 +27,7 @@ final class ActionType implements ActionTypeInterface
         if ($view->parent instanceof ColumnValueView) {
             $value = $view->parent->value;
 
-            $callableOptions = [
+            $closureOptions = [
                 'label',
                 'translation_domain',
                 'translation_parameters',
@@ -40,8 +40,8 @@ final class ActionType implements ActionTypeInterface
                 'variant',
             ];
 
-            foreach ($callableOptions as $optionName) {
-                if (is_callable($options[$optionName])) {
+            foreach ($closureOptions as $optionName) {
+                if ($options[$optionName] instanceof \Closure) {
                     $options[$optionName] = $options[$optionName]($value);
                 }
             }
@@ -107,16 +107,16 @@ final class ActionType implements ActionTypeInterface
                 'visible' => true,
                 'variant' => null,
             ])
-            ->setAllowedTypes('label', ['null', 'bool', 'string', 'callable', TranslatableInterface::class])
-            ->setAllowedTypes('translation_domain', ['null', 'bool', 'string', 'callable'])
-            ->setAllowedTypes('translation_parameters', ['array', 'callable'])
-            ->setAllowedTypes('block_prefix', ['null', 'string', 'callable'])
-            ->setAllowedTypes('attr', ['array', 'callable'])
-            ->setAllowedTypes('icon', ['null', 'string', 'callable'])
-            ->setAllowedTypes('icon_attr', ['array', 'callable'])
-            ->setAllowedTypes('confirmation', ['bool', 'array', 'callable'])
-            ->setAllowedTypes('visible', ['bool', 'callable'])
-            ->setAllowedTypes('variant', ['null', 'string', 'callable'])
+            ->setAllowedTypes('label', ['null', 'bool', 'string', \Closure::class, TranslatableInterface::class])
+            ->setAllowedTypes('translation_domain', ['null', 'bool', 'string', \Closure::class])
+            ->setAllowedTypes('translation_parameters', ['array', \Closure::class])
+            ->setAllowedTypes('block_prefix', ['null', 'string', \Closure::class])
+            ->setAllowedTypes('attr', ['array', \Closure::class])
+            ->setAllowedTypes('icon', ['null', 'string', \Closure::class])
+            ->setAllowedTypes('icon_attr', ['array', \Closure::class])
+            ->setAllowedTypes('confirmation', ['bool', 'array', \Closure::class])
+            ->setAllowedTypes('visible', ['bool', \Closure::class])
+            ->setAllowedTypes('variant', ['null', 'string', \Closure::class])
         ;
     }
 

--- a/src/Action/Type/Dropdown/DropdownActionType.php
+++ b/src/Action/Type/Dropdown/DropdownActionType.php
@@ -18,7 +18,7 @@ class DropdownActionType extends AbstractActionType
     {
         $itemActions = [];
 
-        if (is_callable($options['actions']) && $view->parent instanceof ColumnValueView) {
+        if ($options['actions'] instanceof \Closure && $view->parent instanceof ColumnValueView) {
             $options['actions'] = $options['actions']($view->parent->value);
         }
 
@@ -44,7 +44,7 @@ class DropdownActionType extends AbstractActionType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->define('actions')
-            ->allowedTypes(ActionBuilderInterface::class.'[]', 'callable')
+            ->allowedTypes(ActionBuilderInterface::class.'[]', \Closure::class)
             ->required()
             ->info('The actions to display in the dropdown.')
         ;

--- a/src/Action/Type/FormActionType.php
+++ b/src/Action/Type/FormActionType.php
@@ -18,7 +18,7 @@ final class FormActionType extends AbstractActionType
             $value = $view->parent->value;
 
             foreach (['method', 'action', 'button_attr'] as $optionName) {
-                if (is_callable($options[$optionName])) {
+                if ($options[$optionName] instanceof \Closure) {
                     $options[$optionName] = $options[$optionName]($value);
                 }
             }
@@ -47,9 +47,9 @@ final class FormActionType extends AbstractActionType
                 'action' => '#',
                 'button_attr' => [],
             ])
-            ->setAllowedTypes('method', ['string', 'callable'])
-            ->setAllowedTypes('action', ['string', 'callable'])
-            ->setAllowedTypes('button_attr', ['array', 'callable'])
+            ->setAllowedTypes('method', ['string', \Closure::class])
+            ->setAllowedTypes('action', ['string', \Closure::class])
+            ->setAllowedTypes('button_attr', ['array', \Closure::class])
         ;
     }
 

--- a/src/Action/Type/LinkActionType.php
+++ b/src/Action/Type/LinkActionType.php
@@ -17,7 +17,7 @@ final class LinkActionType extends AbstractActionType
             $value = $view->parent->value;
 
             foreach (['href', 'target'] as $optionName) {
-                if (is_callable($options[$optionName])) {
+                if ($options[$optionName] instanceof \Closure) {
                     $options[$optionName] = $options[$optionName]($value);
                 }
             }
@@ -36,8 +36,8 @@ final class LinkActionType extends AbstractActionType
                 'href' => '#',
                 'target' => null,
             ])
-            ->setAllowedTypes('href', ['string', 'callable'])
-            ->setAllowedTypes('target', ['null', 'string', 'callable'])
+            ->setAllowedTypes('href', ['string', \Closure::class])
+            ->setAllowedTypes('target', ['null', 'string', \Closure::class])
         ;
     }
 }

--- a/src/Action/Type/ModalActionType.php
+++ b/src/Action/Type/ModalActionType.php
@@ -28,14 +28,14 @@ final class ModalActionType extends AbstractActionType
             $value = $view->parent->value;
 
             foreach (['href', 'route', 'route_params'] as $optionName) {
-                if (isset($options[$optionName]) && is_callable($options[$optionName])) {
+                if (isset($options[$optionName]) && $options[$optionName] instanceof \Closure) {
                     $options[$optionName] = $options[$optionName]($value);
                 }
             }
         } else {
             foreach (['href', 'route', 'route_params'] as $optionName) {
-                if (isset($options[$optionName]) && is_callable($options[$optionName])) {
-                    throw new LogicException(sprintf('Callable used for option "%s", but it\'s only available for RowActions.', $optionName));
+                if (isset($options[$optionName]) && $options[$optionName] instanceof \Closure) {
+                    throw new LogicException(sprintf('Closure used for option "%s", but it\'s only available for RowActions.', $optionName));
                 }
             }
         }
@@ -52,19 +52,19 @@ final class ModalActionType extends AbstractActionType
         $resolver
             ->define('route')
             ->default(null)
-            ->allowedTypes('null', 'string', 'callable')
+            ->allowedTypes('null', 'string', \Closure::class)
         ;
 
         $resolver
             ->define('route_params')
-            ->allowedTypes('array', 'callable')
+            ->allowedTypes('array', \Closure::class)
             ->default([])
         ;
 
         $resolver
             ->define('href')
             ->default(null)
-            ->allowedTypes('null', 'string', 'callable')
+            ->allowedTypes('null', 'string', \Closure::class)
         ;
     }
 }

--- a/src/Bridge/Doctrine/Orm/Filter/Formatter/EntityActiveFilterFormatter.php
+++ b/src/Bridge/Doctrine/Orm/Filter/Formatter/EntityActiveFilterFormatter.php
@@ -18,7 +18,7 @@ class EntityActiveFilterFormatter
             return PropertyAccess::createPropertyAccessor()->getValue($data->getValue(), $choiceLabel);
         }
 
-        if (is_callable($choiceLabel)) {
+        if ($choiceLabel instanceof \Closure) {
             return $choiceLabel($data->getValue());
         }
 

--- a/src/Bridge/Doctrine/Orm/Filter/Type/CallbackFilterType.php
+++ b/src/Bridge/Doctrine/Orm/Filter/Type/CallbackFilterType.php
@@ -31,7 +31,7 @@ class CallbackFilterType extends AbstractDoctrineOrmFilterType
         $resolver
             ->setDefault('supported_operators', Operator::cases())
             ->setRequired('callback')
-            ->setAllowedTypes('callback', ['callable'])
+            ->setAllowedTypes('callback', [\Closure::class])
         ;
     }
 }

--- a/src/Bridge/Doctrine/Orm/Filter/Type/EntityFilterType.php
+++ b/src/Bridge/Doctrine/Orm/Filter/Type/EntityFilterType.php
@@ -32,7 +32,7 @@ final class EntityFilterType extends AbstractDoctrineOrmFilterType
                 'choice_label' => null,
                 'active_filter_formatter' => new EntityActiveFilterFormatter(),
             ])
-            ->setAllowedTypes('choice_label', ['null', 'string', 'callable'])
+            ->setAllowedTypes('choice_label', ['null', 'string', \Closure::class])
         ;
 
         // The persistence feature is saving the identifier of the entity, not the entire selected entity.

--- a/src/Bridge/OpenSpout/Exporter/Type/AbstractOpenSpoutExporterType.php
+++ b/src/Bridge/OpenSpout/Exporter/Type/AbstractOpenSpoutExporterType.php
@@ -109,7 +109,7 @@ abstract class AbstractOpenSpoutExporterType extends AbstractExporterType
     {
         $style = $options[$optionName] ?? null;
 
-        if (is_callable($style)) {
+        if ($style instanceof \Closure) {
             $style = $style($view, $options);
         }
 

--- a/src/Bridge/OpenSpout/Exporter/Type/OpenSpoutExporterType.php
+++ b/src/Bridge/OpenSpout/Exporter/Type/OpenSpoutExporterType.php
@@ -33,10 +33,10 @@ final class OpenSpoutExporterType extends AbstractExporterType
                 'value_row_style' => null,
                 'value_cell_style' => null,
             ])
-            ->setAllowedTypes('header_row_style', ['null', 'callable', Style::class])
-            ->setAllowedTypes('header_cell_style', ['null', 'callable', Style::class])
-            ->setAllowedTypes('value_row_style', ['null', 'callable', Style::class])
-            ->setAllowedTypes('value_cell_style', ['null', 'callable', Style::class])
+            ->setAllowedTypes('header_row_style', ['null', \Closure::class, Style::class])
+            ->setAllowedTypes('header_cell_style', ['null', \Closure::class, Style::class])
+            ->setAllowedTypes('value_row_style', ['null', \Closure::class, Style::class])
+            ->setAllowedTypes('value_cell_style', ['null', \Closure::class, Style::class])
         ;
     }
 }

--- a/src/Bridge/PhpSpreadsheet/Exporter/Type/HtmlExporterType.php
+++ b/src/Bridge/PhpSpreadsheet/Exporter/Type/HtmlExporterType.php
@@ -30,7 +30,7 @@ final class HtmlExporterType extends AbstractPhpSpreadsheetExporterType
             ->setAllowedTypes('embed_images', 'bool')
             ->setAllowedTypes('use_inline_css', 'bool')
             ->setAllowedTypes('generate_sheet_navigation_block', 'bool')
-            ->setAllowedTypes('edit_html_callback', ['null', 'callable'])
+            ->setAllowedTypes('edit_html_callback', ['null', \Closure::class])
             ->setAllowedTypes('decimal_separator', 'string')
             ->setAllowedTypes('thousands_separator', 'string')
         ;

--- a/src/Column/Type/ActionsColumnType.php
+++ b/src/Column/Type/ActionsColumnType.php
@@ -65,8 +65,8 @@ final class ActionsColumnType extends AbstractColumnType
                         'visible' => true,
                     ])
                     ->setAllowedTypes('type', ['string'])
-                    ->setAllowedTypes('type_options', ['array', 'callable'])
-                    ->setAllowedTypes('visible', ['bool', 'callable'])
+                    ->setAllowedTypes('type_options', ['array', \Closure::class])
+                    ->setAllowedTypes('visible', ['bool', \Closure::class])
                     ->setInfo('type', 'A fully-qualified class name of the action type.')
                     ->setInfo('type_options', 'An array of options passed to the action type.')
                     ->setInfo('visible', 'Determines whether the action should be visible.')
@@ -104,7 +104,7 @@ final class ActionsColumnType extends AbstractColumnType
 
         $visible = $action['visible'];
 
-        if ($view instanceof ColumnValueView && is_callable($visible)) {
+        if ($view instanceof ColumnValueView && $visible instanceof \Closure) {
             $visible = $visible($view->value);
         }
 

--- a/src/Column/Type/ColumnType.php
+++ b/src/Column/Type/ColumnType.php
@@ -89,7 +89,9 @@ final class ColumnType implements ColumnTypeInterface
         $view->data = $data;
         $view->value = $value;
 
-        if (is_callable($attr = $options['value_attr'])) {
+        $attr = $options['value_attr'];
+
+        if ($attr instanceof \Closure) {
             $attr = $attr($data, $rowData);
         }
 
@@ -102,7 +104,9 @@ final class ColumnType implements ColumnTypeInterface
             $translationKey ??= $value;
         }
 
-        if (is_callable($translationParameters = $options['value_translation_parameters'])) {
+        $translationParameters = $options['value_translation_parameters'];
+
+        if ($translationParameters instanceof \Closure) {
             $translationParameters = $translationParameters($data, $rowData);
         }
 
@@ -198,11 +202,11 @@ final class ColumnType implements ColumnTypeInterface
                 $translationDomain = $options['export']['value_translation_domain'];
                 $translationParameters = $options['export']['value_translation_parameters'];
 
-                if (is_callable($translationParameters)) {
+                if ($translationParameters instanceof \Closure) {
                     $translationParameters = $translationParameters($data, $rowData);
                 }
 
-                if (is_string($value)) {
+                if ($value instanceof \Closure) {
                     $translationKey ??= $value;
                 }
 
@@ -255,7 +259,7 @@ final class ColumnType implements ColumnTypeInterface
 
         $resolver->define('value_translation_parameters')
             ->default([])
-            ->allowedTypes('array', 'callable')
+            ->allowedTypes('array', \Closure::class)
             ->info('Translation parameters used to translate the column value.')
         ;
 
@@ -279,7 +283,7 @@ final class ColumnType implements ColumnTypeInterface
 
         $resolver->define('formatter')
             ->default(null)
-            ->allowedTypes('null', 'callable')
+            ->allowedTypes('null', \Closure::class)
             ->info('Formatter to use on non-empty value to customize it even further before rendering. Column value and row data are passed as arguments.')
         ;
 
@@ -297,8 +301,8 @@ final class ColumnType implements ColumnTypeInterface
 
         $resolver->define('getter')
             ->default(null)
-            ->allowedTypes('null', 'callable')
-            ->info('Callable used to retrieve column value from row data. If set, it is used instead of property accessor.')
+            ->allowedTypes('null', \Closure::class)
+            ->info('Closure used to retrieve column value from row data. If set, it is used instead of property accessor.')
         ;
 
         $resolver->define('header_attr')
@@ -309,7 +313,7 @@ final class ColumnType implements ColumnTypeInterface
 
         $resolver->define('value_attr')
             ->default([])
-            ->allowedTypes('array', 'callable')
+            ->allowedTypes('array', \Closure::class)
             ->info('Extra HTML attributes to render on the column value.')
         ;
 
@@ -348,7 +352,9 @@ final class ColumnType implements ColumnTypeInterface
             return null;
         }
 
-        if (is_callable($getter = $options['getter'])) {
+        $getter = $options['getter'];
+
+        if ($getter instanceof \Closure) {
             return $getter($rowData, $column, $options);
         }
 
@@ -369,7 +375,9 @@ final class ColumnType implements ColumnTypeInterface
 
         $value = $data;
 
-        if (is_callable($formatter = $options['formatter'])) {
+        $formatter = $options['formatter'];
+
+        if ($formatter instanceof \Closure) {
             $value = $formatter($data, $rowData, $column, $options);
         }
 

--- a/src/Column/Type/IconColumnType.php
+++ b/src/Column/Type/IconColumnType.php
@@ -16,7 +16,7 @@ final class IconColumnType extends AbstractColumnType
     public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
     {
         foreach (['icon', 'icon_attr'] as $optionName) {
-            if (is_callable($options[$optionName])) {
+            if ($options[$optionName] instanceof \Closure) {
                 $options[$optionName] = $options[$optionName]($view->value);
             }
         }
@@ -31,13 +31,13 @@ final class IconColumnType extends AbstractColumnType
     {
         $resolver->define('icon')
             ->required()
-            ->allowedTypes('string', 'callable')
+            ->allowedTypes('string', \Closure::class)
             ->info('Defines the icon to render.')
         ;
 
         $resolver->define('icon_attr')
             ->default([])
-            ->allowedTypes('array', 'callable')
+            ->allowedTypes('array', \Closure::class)
             ->info('Defines the HTML attributes for the icon to render.')
         ;
     }

--- a/src/Column/Type/LinkColumnType.php
+++ b/src/Column/Type/LinkColumnType.php
@@ -20,11 +20,15 @@ final class LinkColumnType extends AbstractColumnType
 {
     public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
     {
-        if (is_callable($href = $options['href'])) {
+        $href = $options['href'];
+
+        if ($href instanceof \Closure) {
             $href = $href($view->vars['data'], $view->parent->data, $column);
         }
 
-        if (is_callable($target = $options['target'])) {
+        $target = $options['target'];
+
+        if ($target instanceof \Closure) {
             $target = $target($view->vars['data'], $view->parent->data, $column);
         }
 
@@ -38,13 +42,13 @@ final class LinkColumnType extends AbstractColumnType
     {
         $resolver->define('href')
             ->default('#')
-            ->allowedTypes('string', 'callable')
+            ->allowedTypes('string', \Closure::class)
             ->info('Defines the URL to link to.')
         ;
 
         $resolver->define('target')
             ->default(null)
-            ->allowedTypes('null', 'string', 'callable')
+            ->allowedTypes('null', 'string', \Closure::class)
             ->info('Sets the value that will be used as a "target" HTML attribute.')
         ;
     }

--- a/src/Column/Type/MoneyColumnType.php
+++ b/src/Column/Type/MoneyColumnType.php
@@ -18,7 +18,9 @@ final class MoneyColumnType extends AbstractColumnType
 {
     public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
     {
-        if (is_callable($currency = $options['currency'])) {
+        $currency = $options['currency'];
+
+        if ($currency instanceof \Closure) {
             $currency = $currency($view->parent->data);
         }
 
@@ -38,7 +40,7 @@ final class MoneyColumnType extends AbstractColumnType
     {
         $resolver->define('currency')
             ->required()
-            ->allowedTypes('string', 'callable')
+            ->allowedTypes('string', \Closure::class)
         ;
 
         $resolver->define('divisor')

--- a/src/Column/Type/TemplateColumnType.php
+++ b/src/Column/Type/TemplateColumnType.php
@@ -17,11 +17,14 @@ final class TemplateColumnType extends AbstractColumnType
 {
     public function buildValueView(ColumnValueView $view, ColumnInterface $column, array $options): void
     {
-        if (is_callable($templatePath = $options['template_path'])) {
+        $templatePath = $options['template_path'];
+        $templateVars = $options['template_vars'];
+
+        if ($templatePath instanceof \Closure) {
             $templatePath = $templatePath($view->data, $column);
         }
 
-        if (is_callable($templateVars = $options['template_vars'])) {
+        if ($templateVars instanceof \Closure) {
             $templateVars = $templateVars($view->data, $column);
         }
 
@@ -35,13 +38,13 @@ final class TemplateColumnType extends AbstractColumnType
     {
         $resolver->define('template_path')
             ->required()
-            ->allowedTypes('string', 'callable')
+            ->allowedTypes('string', \Closure::class)
             ->info('A path to the template that should be rendered.')
         ;
 
         $resolver->define('template_vars')
             ->default([])
-            ->allowedTypes('array', 'callable')
+            ->allowedTypes('array', \Closure::class)
             ->info('An array of variables passed to the template.')
         ;
     }

--- a/src/Exporter/Type/CallbackExporterType.php
+++ b/src/Exporter/Type/CallbackExporterType.php
@@ -20,7 +20,7 @@ final class CallbackExporterType extends AbstractExporterType
     {
         $resolver
             ->setRequired('callback')
-            ->setAllowedTypes('callback', ['callable'])
+            ->setAllowedTypes('callback', [\Closure::class])
         ;
     }
 }

--- a/src/Filter/Type/CallbackFilterType.php
+++ b/src/Filter/Type/CallbackFilterType.php
@@ -22,7 +22,7 @@ final class CallbackFilterType extends AbstractFilterType implements FilterHandl
     {
         $resolver
             ->setRequired('callback')
-            ->setAllowedTypes('callback', 'callable')
+            ->setAllowedTypes('callback', [\Closure::class])
         ;
     }
 

--- a/src/Filter/Type/FilterType.php
+++ b/src/Filter/Type/FilterType.php
@@ -95,7 +95,7 @@ final class FilterType implements FilterTypeInterface
             ->setAllowedTypes('default_operator', Operator::class)
             ->setAllowedTypes('supported_operators', Operator::class.'[]')
             ->setAllowedTypes('operator_selectable', 'bool')
-            ->setAllowedTypes('active_filter_formatter', ['null', 'callable'])
+            ->setAllowedTypes('active_filter_formatter', ['null', \Closure::class])
             ->setAllowedValues('translation_domain', function (mixed $value): bool {
                 return is_null($value) || false === $value || is_string($value);
             })

--- a/src/Filter/Type/SearchFilterType.php
+++ b/src/Filter/Type/SearchFilterType.php
@@ -28,7 +28,7 @@ class SearchFilterType extends AbstractFilterType implements SearchFilterTypeInt
                 'label' => false,
             ])
             ->setRequired('handler')
-            ->setAllowedTypes('handler', 'callable')
+            ->setAllowedTypes('handler', [\Closure::class])
             ->addNormalizer('form_options', function (Options $options, array $value): array {
                 return $value + [
                     'attr' => ($value['attr'] ?? []) + ['placeholder' => 'Search...'],

--- a/src/Type/DataTableType.php
+++ b/src/Type/DataTableType.php
@@ -314,7 +314,7 @@ final class DataTableType implements DataTableTypeInterface
             $valueRowView->vars['row'] = $valueRowView;
 
             foreach ($dataTable->getConfig()->getValueRowAttributes() as $key => $value) {
-                if (is_callable($value)) {
+                if ($value instanceof \Closure) {
                     $value = $value($data, $dataTable);
                 }
 


### PR DESCRIPTION
There are many places, where options would accept the `callable` type and use `is_callable` on them. This is way too broad and makes a low of unexpected cases, for example, this simple action:

```php
$builder->addRowAction('sendInvoice', ButtonActionType::class, [
    'icon' => 'file',
]);
```

Above action doesn't work, because its icon is `"file"` (string), but `file` is a callable PHP function, which results in the error:

```
file(): Argument #1 ($filename) must be of type string, <entity FQCN> given
```

Those errors are hard and annoying to debug. Bundle will now accept `\Closure` types and check whether the value is `instanceof \Closure::class`. 

**While this is a breaking change, unless your application is providing strings in those options and expect a PHP function to be called, everything should be compatible.**