### PR TITLE
Column filters

### DIFF
--- a/assets/controllers/column-filter.js
+++ b/assets/controllers/column-filter.js
@@ -1,0 +1,36 @@
+import { Controller } from '@hotwired/stimulus'
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        delay: { type: Number, default: 400 },
+    }
+
+    static targets = ['form']
+
+    connect() {
+        this.timeout = null
+    }
+
+    disconnect() {
+        this.clear()
+    }
+
+    queueSubmit() {
+        this.clear()
+        this.timeout = setTimeout(() => {
+            if (this.formTarget.requestSubmit) {
+                this.formTarget.requestSubmit()
+            } else {
+                this.formTarget.submit()
+            }
+        }, this.delayValue)
+    }
+
+    clear() {
+        if (this.timeout) {
+            clearTimeout(this.timeout)
+            this.timeout = null
+        }
+    }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -24,6 +24,11 @@
                 "main": "controllers/bootstrap/modal.js",
                 "fetch": "eager",
                 "enabled": false
+            },
+            "column-filter": {
+                "main": "controllers/column-filter.js",
+                "fetch": "eager",
+                "enabled": true
             }
         },
         "importmap": {

--- a/docs/src/docs/components/filters.md
+++ b/docs/src/docs/components/filters.md
@@ -34,6 +34,43 @@ This method accepts _three_ arguments:
 
 For reference, see [available filter types](../../reference/types/filter.md).
 
+### Column filters
+
+You can also add a filter directly to a column, which will display the filter in the column header.  
+To do this, use the `filter` and (optionally) `filter_options` keys in the column definition:
+
+```php
+$builder
+    ->addColumn('name', TextColumnType::class, [
+        'label' => 'Full name',
+        'sort' => true,
+        'filter' => StringFilterType::class,
+    ]);
+```
+
+You can pass options to the filter using the `filter_options` array:
+
+```php
+$builder
+    ->addColumn('name', TextColumnType::class, [
+        'label' => 'Full name',
+        'sort' => true,
+        'filter' => StringFilterType::class,
+        'filter_options' => [
+            'operator_selectable' => true,
+        ],
+    ]);
+```
+
+- `filter`: The filter type class (e.g. `StringFilterType::class`)
+- `filter_options`: An array of options passed to the filter (e.g. `operator_selectable`, `default_operator`, etc.)
+
+Column filters are rendered inside the column header and are scoped to the column they are defined on.
+
+> **Note:**  
+> A field cannot have both a header filter (via `addFilter()`) and a column filter (via the column's `filter` option) at the same time.  
+> Attempting to add both types of filters for the same field will result in an `InvalidArgumentException`.
+
 ### Case-insensitive filters for Postgres or MySQL with a case sensitive collation
 
 If your database does `LIKE` comparisons in a case-sensitive manner (aka `A` is not the same as `a`), but you want

--- a/src/Column/Type/ColumnType.php
+++ b/src/Column/Type/ColumnType.php
@@ -341,6 +341,7 @@ final class ColumnType implements ColumnTypeInterface
                 if (null === $value) {
                     return true;
                 }
+
                 return is_subclass_of($value, AbstractFilterType::class);
             })
             ->info('Provide a Filter Type FQCN (extending AbstractFilterType) to render a per-column filter.')

--- a/src/Column/Type/ColumnType.php
+++ b/src/Column/Type/ColumnType.php
@@ -8,6 +8,7 @@ use Kreyu\Bundle\DataTableBundle\Column\ColumnBuilderInterface;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnHeaderView;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
 use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
+use Kreyu\Bundle\DataTableBundle\Filter\Type\AbstractFilterType;
 use Kreyu\Bundle\DataTableBundle\Util\StringUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -73,6 +74,8 @@ final class ColumnType implements ColumnTypeInterface
             'sort_direction' => $sortColumnData?->getDirection(),
             'sortable' => $column->getConfig()->isSortable(),
             'export' => $column->getConfig()->isExportable(),
+            'filter' => $options['filter'],
+            'filter_options' => $options['filter_options'],
         ]);
     }
 
@@ -329,6 +332,24 @@ final class ColumnType implements ColumnTypeInterface
             ->default(true)
             ->allowedTypes('bool')
             ->info('Defines whether the column can be personalized by the user in personalization feature.')
+        ;
+
+        $resolver->define('filter')
+            ->default(null)
+            ->allowedTypes('string', 'null')
+            ->allowedValues(function (?string $value): bool {
+                if (null === $value) {
+                    return true;
+                }
+                return is_subclass_of($value, AbstractFilterType::class);
+            })
+            ->info('Provide a Filter Type FQCN (extending AbstractFilterType) to render a per-column filter.')
+        ;
+
+        $resolver->define('filter_options')
+            ->default([])
+            ->allowedTypes('array')
+            ->info('Options passed to the per-column filter type when rendering the inline filter in the header.')
         ;
     }
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -574,21 +574,6 @@ class DataTable implements DataTableInterface
 
         $filters = $this->getFilters();
 
-        foreach ($this->getColumns() as $column) {
-            $typeFqcn = $column->getConfig()->getOption('filter', false);
-            if ($typeFqcn && is_string($typeFqcn)) {
-                $name = $column->getName();
-                // Avoid overriding an existing filter with the same name
-                if (!isset($filters[$name])) {
-                    $options = $column->getConfig()->getOption('filter_options', []);
-                    $filter = $this->config->getFilterFactory()->createNamed($name, $typeFqcn, $options);
-                    // Attach data table context for consistency
-                    $filter->setDataTable($this);
-                    $filters[$name] = $filter;
-                }
-            }
-        }
-
         $data->appendMissingFilters($filters);
         $data->removeRedundantFilters($filters);
 
@@ -798,7 +783,7 @@ class DataTable implements DataTableInterface
             options: [
                 'data_table' => $this,
                 'data_table_view' => $view,
-                'filters' => $filters,
+                'is_header_form' => false,
             ],
         );
     }

--- a/src/DataTableConfigBuilder.php
+++ b/src/DataTableConfigBuilder.php
@@ -845,6 +845,11 @@ class DataTableConfigBuilder implements DataTableConfigBuilderInterface
         return $this->getParameterName(static::FILTRATION_PARAMETER);
     }
 
+    public function getColumnFiltrationParameterName(): string
+    {
+        return $this->getParameterName(static::COLUMN_FILTRATION_PARAMETER);
+    }
+
     public function getPersonalizationParameterName(): string
     {
         return $this->getParameterName(static::PERSONALIZATION_PARAMETER);

--- a/src/DataTableConfigInterface.php
+++ b/src/DataTableConfigInterface.php
@@ -26,6 +26,7 @@ interface DataTableConfigInterface
     public const PER_PAGE_PARAMETER = 'limit';
     public const SORT_PARAMETER = 'sort';
     public const FILTRATION_PARAMETER = 'filter';
+    public const COLUMN_FILTRATION_PARAMETER = 'filter_column';
     public const PERSONALIZATION_PARAMETER = 'personalization';
     public const EXPORT_PARAMETER = 'export';
 
@@ -130,6 +131,8 @@ interface DataTableConfigInterface
     public function getSortParameterName(): string;
 
     public function getFiltrationParameterName(): string;
+
+    public function getColumnFiltrationParameterName(): string;
 
     public function getPersonalizationParameterName(): string;
 

--- a/src/DataTableInterface.php
+++ b/src/DataTableInterface.php
@@ -202,6 +202,8 @@ interface DataTableInterface
 
     public function createFiltrationFormBuilder(?DataTableView $view = null): FormBuilderInterface;
 
+    public function createColumnFiltrationFormBuilder(?DataTableView $view = null, array $filters = []): FormBuilderInterface;
+
     public function createPersonalizationFormBuilder(?DataTableView $view = null): FormBuilderInterface;
 
     public function createExportFormBuilder(?DataTableView $view = null): FormBuilderInterface;

--- a/src/Filter/FilterClearUrlGenerator.php
+++ b/src/Filter/FilterClearUrlGenerator.php
@@ -60,7 +60,7 @@ class FilterClearUrlGenerator implements FilterClearUrlGeneratorInterface
         $dataTableView = $filterView->parent;
 
         return [
-            $dataTableView->vars['filtration_parameter_name'] => [
+            $dataTableView->vars[$filterView->vars['is_header_filter'] ? 'filtration_parameter_name' : 'column_filtration_parameter_name'] => [
                 $filterView->vars['name'] => $parameters,
             ],
         ];

--- a/src/Filter/FilterConfigBuilder.php
+++ b/src/Filter/FilterConfigBuilder.php
@@ -25,6 +25,7 @@ class FilterConfigBuilder implements FilterConfigBuilderInterface
     private array $supportedOperators = [];
     private Operator $defaultOperator = Operator::Equals;
     private bool $operatorSelectable = false;
+    private bool $isHeaderFilter = true;
     private FilterData $emptyData;
 
     public function __construct(
@@ -289,6 +290,22 @@ class FilterConfigBuilder implements FilterConfigBuilderInterface
         $config->locked = true;
 
         return $config;
+    }
+
+    public function isHeaderFilter(): bool
+    {
+        return $this->isHeaderFilter;
+    }
+
+    public function setIsHeaderFilter(bool $isHeaderFilter): self
+    {
+        if ($this->locked) {
+            throw $this->createBuilderLockedException();
+        }
+
+        $this->isHeaderFilter = $isHeaderFilter;
+
+        return $this;
     }
 
     private function createBuilderLockedException(): BadMethodCallException

--- a/src/Filter/FilterConfigBuilderInterface.php
+++ b/src/Filter/FilterConfigBuilderInterface.php
@@ -46,4 +46,6 @@ interface FilterConfigBuilderInterface extends FilterConfigInterface
     public function setOperatorSelectable(bool $operatorSelectable): static;
 
     public function getFilterConfig(): FilterConfigInterface;
+
+    public function setIsHeaderFilter(bool $isHeaderFilter): self;
 }

--- a/src/Filter/FilterConfigInterface.php
+++ b/src/Filter/FilterConfigInterface.php
@@ -52,4 +52,6 @@ interface FilterConfigInterface
     public function getDefaultOperator(): Operator;
 
     public function isOperatorSelectable(): bool;
+
+    public function isHeaderFilter(): bool;
 }

--- a/src/Filter/Type/FilterType.php
+++ b/src/Filter/Type/FilterType.php
@@ -27,6 +27,7 @@ final class FilterType implements FilterTypeInterface
             'default_operator' => $builder->setDefaultOperator(...),
             'supported_operators' => $builder->setSupportedOperators(...),
             'operator_selectable' => $builder->setOperatorSelectable(...),
+            'is_header_filter' => $builder->setIsHeaderFilter(...),
         ];
 
         foreach ($setters as $option => $setter) {
@@ -62,6 +63,7 @@ final class FilterType implements FilterTypeInterface
             'operator_selectable' => $filter->getConfig()->isOperatorSelectable(),
             'default_operator' => $filter->getConfig()->getDefaultOperator(),
             'supported_operators' => $filter->getConfig()->getSupportedOperators(),
+            'is_header_filter' => $filter->getConfig()->isHeaderFilter(),
             'data' => $view->data,
             'value' => $view->value,
         ]);
@@ -83,6 +85,7 @@ final class FilterType implements FilterTypeInterface
                 'supported_operators' => [],
                 'operator_selectable' => false,
                 'active_filter_formatter' => null,
+                'is_header_filter' => true,
             ])
             ->setAllowedTypes('label', ['null', 'bool', 'string', TranslatableInterface::class])
             ->setAllowedTypes('label_translation_parameters', 'array')
@@ -96,6 +99,7 @@ final class FilterType implements FilterTypeInterface
             ->setAllowedTypes('supported_operators', Operator::class.'[]')
             ->setAllowedTypes('operator_selectable', 'bool')
             ->setAllowedTypes('active_filter_formatter', ['null', 'callable'])
+            ->setAllowedTypes('is_header_filter', ['bool'])
             ->setAllowedValues('translation_domain', function (mixed $value): bool {
                 return is_null($value) || false === $value || is_string($value);
             })

--- a/src/Request/HttpFoundationRequestHandler.php
+++ b/src/Request/HttpFoundationRequestHandler.php
@@ -6,7 +6,6 @@ namespace Kreyu\Bundle\DataTableBundle\Request;
 
 use Kreyu\Bundle\DataTableBundle\DataTableInterface;
 use Kreyu\Bundle\DataTableBundle\Exception\UnexpectedTypeException;
-use Kreyu\Bundle\DataTableBundle\Filter\FiltrationData;
 use Kreyu\Bundle\DataTableBundle\Pagination\PaginationData;
 use Kreyu\Bundle\DataTableBundle\Pagination\PaginationInterface;
 use Kreyu\Bundle\DataTableBundle\Sorting\SortingData;
@@ -46,53 +45,25 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             return;
         }
 
-        $mainForm = $dataTable->createFiltrationFormBuilder()->getForm();
+        $form = $dataTable->createFiltrationFormBuilder()->getForm();
 
-        // Build ad-hoc per-column filters from column configuration (type + options)
-        $columnFilters = [];
-        foreach ($dataTable->getColumns() as $column) {
-            $typeFqcn = $column->getConfig()->getOption('filter', false);
-            if ($typeFqcn && is_string($typeFqcn)) {
-                $filterName = $column->getName();
-                $options = $column->getConfig()->getOption('filter_options', []);
-                $columnFilters[] = $dataTable->getConfig()->getFilterFactory()->createNamed($filterName, $typeFqcn, $options);
-            }
+        if ($data = $request->get($form->getName())) {
+            $form->submit($data);
         }
-        $columnForm = $dataTable->createColumnFiltrationFormBuilder(null, $columnFilters)->getForm();
 
-        if ($data = $request->get($mainForm->getName())) {
-            $mainForm->submit($data);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $dataTable->filter($form->getData());
         }
+
+        $columnForm = $dataTable->createColumnFiltrationFormBuilder()->getForm();
+
         if ($data = $request->get($columnForm->getName())) {
             $columnForm->submit($data);
         }
 
-        $submitted = ($mainForm->isSubmitted() && $mainForm->isValid()) || ($columnForm->isSubmitted() && $columnForm->isValid());
-        if (!$submitted) {
-            return;
-        }
-
-        // Start from current filtration data (or defaults), then override with submitted values.
-        $merged = $dataTable->getFiltrationData();
-        if (null === $merged) {
-            $merged = $dataTable->getConfig()->getDefaultFiltrationData() ?? FiltrationData::fromDataTable($dataTable);
-        }
-
-        if ($mainForm->isSubmitted() && $mainForm->isValid()) {
-            $data = $mainForm->getData();
-            foreach ($data->getFilters() as $name => $filterData) {
-                $merged->setFilterData($name, $filterData);
-            }
-        }
-
         if ($columnForm->isSubmitted() && $columnForm->isValid()) {
-            $data = $columnForm->getData();
-            foreach ($data->getFilters() as $name => $filterData) {
-                $merged->setFilterData($name, $filterData);
-            }
+            $dataTable->filter($columnForm->getData());
         }
-
-        $dataTable->filter($merged);
     }
 
     private function sort(DataTableInterface $dataTable, Request $request): void

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -15,6 +15,7 @@
             data-kreyu--data-table-bundle--state-url-query-parameters-value="{{ url_query_parameters|default({})|json_encode(constant('JSON_FORCE_OBJECT')) }}"
         >
             {{ block('action_bar', theme) }}
+            {{ block('kreyu_data_table_column_filters_form', theme) }}
             {{ block('table', theme) }}
 
             {% if pagination_enabled %}
@@ -367,6 +368,28 @@
     {% endif %}
 {% endblock %}
 
+{# Column filtration (per-column filters), independent from header filters #}
+{% block kreyu_data_table_column_filters_form %}
+    {% set form = data_table.vars.column_filtration_form|default(null) %}
+    {% if form %}
+        {% form_theme form with form_themes|default([_self]) %}
+        {{ form_start(form, { attr: { 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', 'hidden': 'hidden' } }) }}
+        {{ form_end(form, { render_rest: false }) }}
+
+        {% set data_table = form.vars.data_table_view %}
+        {% if data_table.vars.pagination_enabled %}
+            {% set url_query_parameters = [] %}
+            {% if should_reset_to_first_page ?? true %}
+                {% set url_query_parameters = url_query_parameters|merge({ (data_table.vars.page_parameter_name): 1 }) %}
+            {% endif %}
+            {% if should_keep_per_page ?? true %}
+                {% set url_query_parameters = url_query_parameters|merge({ (data_table.vars.per_page_parameter_name): data_table.vars.pagination.vars.item_number_per_page }) %}
+            {% endif %}
+            {{ _self.array_to_form_inputs(url_query_parameters, { form: form.vars.id }) }}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block filtration_widget %}
     <div {{ block('attributes') }}>{{ block('filtration_form', theme) }}</div>
 {% endblock %}
@@ -434,12 +457,50 @@
                     {{ block('sort_arrow_none', theme, _context) }}
                 {% endif %}
             </a>
+            {# Inline column filter input (optional) - also render for sortable columns #}
+            {% if data_table.vars.filtration_enabled and filter %}
+                {% set column_form = data_table.vars.column_filtration_form|default(null) %}
+                {% if column_form %}
+                    {% set filter_name = header_filter_name|default(name) %}
+{#                    {% set filter_child_name = filter_name|replace({'.':'__'}) %}#}
+                    {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
+                        <div class="dtb-column-filter">
+                            {# Prefer rendering the value field for compactness; if not available, render whole child #}
+                            {% set child = attribute(column_form, filter_name) %}
+                            {% if attribute(child, 'value', [], 'any', true, true) is defined %}
+                                {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
+                            {% else %}
+                                {{ form_widget(child, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' } }) }}
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
         </th>
     {% else %}
         <th {{ block('attributes') }}>
             <span {% with { attr: label_attr } %}{{- block('attributes') -}}{% endwith %}>
                 {{- block('column_header_label', theme, _context) -}}
             </span>
+            {# Inline column filter input (optional) #}
+            {% if data_table.vars.filtration_enabled and filter %}
+                {% set column_form = data_table.vars.column_filtration_form|default(null) %}
+                {% if column_form %}
+                    {% set filter_name = header_filter_name|default(name) %}
+                    {% set filter_child_name = filter_name|replace({'.':'__'}) %}
+                    {% if attribute(column_form, filter_child_name, [], 'any', true, true) is defined %}
+                        <div class="dtb-column-filter">
+                            {# Prefer rendering the value field for compactness; if not available, render whole child #}
+                            {% set child = attribute(column_form, filter_child_name) %}
+                            {% if attribute(child, 'value', [], 'any', true, true) is defined %}
+                                {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
+                            {% else %}
+                                {{ form_widget(child, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' } }) }}
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
         </th>
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -462,7 +462,6 @@
                 {% set column_form = data_table.vars.column_filtration_form|default(null) %}
                 {% if column_form %}
                     {% set filter_name = header_filter_name|default(name) %}
-{#                    {% set filter_child_name = filter_name|replace({'.':'__'}) %}#}
                     {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
                         <div class="dtb-column-filter">
                             {# Prefer rendering the value field for compactness; if not available, render whole child #}

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -368,7 +368,6 @@
     {% endif %}
 {% endblock %}
 
-{# Column filtration (per-column filters), independent from header filters #}
 {% block kreyu_data_table_column_filters_form %}
     {% set form = data_table.vars.column_filtration_form|default(null) %}
     {% if form %}
@@ -428,80 +427,52 @@
 {% block column_header %}
     {% set label_attr = label_attr|default({}) %}
 
-    {% if data_table.vars.sorting_enabled and sortable %}
-        {% set active_attr = active_attr|default({}) %}
-        {% set inactive_attr = inactive_attr|default({}) %}
 
-        {% set sorted_attr = sorted ? active_attr : inactive_attr %}
+    <th {{ block('attributes') }}>
+        {% set label_attr = { href: data_table_column_sort_url(data_table, column) }|merge(label_attr) %}
+        {% set label_attr = { 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' }|merge(label_attr) %}
 
-        {# Merge the sorted attr with column header attr, but merge its classes. #}
-        {# The column header attr class is added after the sorted attr class. #}
-        {% set attr = attr|merge(sorted_attr|merge({
-            class: (sorted_attr.class|default('') ~ ' ' ~ attr.class|default(''))|trim
-        })) %}
+        {% if data_table.vars.sorting_enabled and sortable %}
+            {% set active_attr = active_attr|default({}) %}
+            {% set inactive_attr = inactive_attr|default({}) %}
 
-        <th {{ block('attributes') }}>
-            {% set label_attr = { href: data_table_column_sort_url(data_table, column) }|merge(label_attr) %}
-            {% set label_attr = { 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' }|merge(label_attr) %}
+            {% set sorted_attr = sorted ? active_attr : inactive_attr %}
 
-            <a {% with { attr: label_attr } %}{{- block('attributes') -}}{% endwith %}>
-                {{- block('column_header_label', theme, _context) -}}
+            {# Merge the sorted attr with column header attr, but merge its classes. #}
+            {# The column header attr class is added after the sorted attr class. #}
+            {% set attr = attr|merge(sorted_attr|merge({
+                class: (sorted_attr.class|default('') ~ ' ' ~ attr.class|default(''))|trim
+            })) %}
+                <a {% with { attr: label_attr } %}{{- block('attributes') -}}{% endwith %}>
+                    {{- block('column_header_label', theme, _context) -}}
 
-                {% if sorted %}
-                    {% if sort_direction == 'asc' %}
-                        {{ block('sort_arrow_asc', theme, _context) }}
+                    {% if sorted %}
+                        {% if sort_direction == 'asc' %}
+                            {{ block('sort_arrow_asc', theme, _context) }}
+                        {% else %}
+                            {{ block('sort_arrow_desc', theme, _context) }}
+                        {% endif %}
                     {% else %}
-                        {{ block('sort_arrow_desc', theme, _context) }}
+                        {{ block('sort_arrow_none', theme, _context) }}
                     {% endif %}
-                {% else %}
-                    {{ block('sort_arrow_none', theme, _context) }}
-                {% endif %}
-            </a>
-            {# Inline column filter input (optional) - also render for sortable columns #}
-            {% if data_table.vars.filtration_enabled and filter %}
-                {% set column_form = data_table.vars.column_filtration_form|default(null) %}
-                {% if column_form %}
-                    {% set filter_name = header_filter_name|default(name) %}
-                    {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
-                        <div class="dtb-column-filter">
-                            {# Prefer rendering the value field for compactness; if not available, render whole child #}
-                            {% set child = attribute(column_form, filter_name) %}
-                            {% if attribute(child, 'value', [], 'any', true, true) is defined %}
-                                {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
-                            {% else %}
-                                {{ form_widget(child, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' } }) }}
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                {% endif %}
-            {% endif %}
-        </th>
-    {% else %}
-        <th {{ block('attributes') }}>
+                </a>
+        {% else %}
             <span {% with { attr: label_attr } %}{{- block('attributes') -}}{% endwith %}>
                 {{- block('column_header_label', theme, _context) -}}
             </span>
-            {# Inline column filter input (optional) #}
-            {% if data_table.vars.filtration_enabled and filter %}
-                {% set column_form = data_table.vars.column_filtration_form|default(null) %}
-                {% if column_form %}
-                    {% set filter_name = header_filter_name|default(name) %}
-                    {% set filter_child_name = filter_name|replace({'.':'__'}) %}
-                    {% if attribute(column_form, filter_child_name, [], 'any', true, true) is defined %}
-                        <div class="dtb-column-filter">
-                            {# Prefer rendering the value field for compactness; if not available, render whole child #}
-                            {% set child = attribute(column_form, filter_child_name) %}
-                            {% if attribute(child, 'value', [], 'any', true, true) is defined %}
-                                {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
-                            {% else %}
-                                {{ form_widget(child, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self' } }) }}
-                            {% endif %}
-                        </div>
-                    {% endif %}
+        {% endif %}
+
+        {% if data_table.vars.filtration_enabled and filter %}
+            {% set column_form = data_table.vars.column_filtration_form|default(null) %}
+            {% if column_form %}
+                {% set filter_name = header_filter_name|default(name) %}
+                {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
+                    {% set child = attribute(column_form, filter_name) %}
+                    {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
                 {% endif %}
             {% endif %}
-        </th>
-    {% endif %}
+        {% endif %}
+    </th>
 {% endblock %}
 
 {# @see Kreyu\Bundle\DataTableBundle\Column\Type\ColumnType #}

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -468,6 +468,9 @@
                 {% set filter_name = header_filter_name|default(name) %}
                 {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
                     {% set child = attribute(column_form, filter_name) %}
+                    {% if child.operator is defined %}
+                        {{ form_widget(child.operator) }}
+                    {% endif %}
                     {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
                 {% endif %}
             {% endif %}

--- a/src/Resources/views/themes/base.html.twig
+++ b/src/Resources/views/themes/base.html.twig
@@ -9,6 +9,10 @@
         {% set stimulus_controllers = stimulus_controllers|merge(['kreyu--data-table-bundle--batch']) %}
     {% endif %}
 
+    {% if has_column_filters %}
+        {% set stimulus_controllers = stimulus_controllers|merge(['kreyu--data-table-bundle--column-filter']) %}
+    {% endif %}
+
     <turbo-frame id="kreyu_data_table_{{ name }}" target="_top">
         <div
             data-controller="{{ stimulus_controllers|join(' ') }}"
@@ -372,7 +376,7 @@
     {% set form = data_table.vars.column_filtration_form|default(null) %}
     {% if form %}
         {% form_theme form with form_themes|default([_self]) %}
-        {{ form_start(form, { attr: { 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', 'hidden': 'hidden' } }) }}
+        {{ form_start(form, { attr: { 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', 'hidden': 'hidden', 'data-kreyu--data-table-bundle--column-filter-target': 'form' } }) }}
         {{ form_end(form, { render_rest: false }) }}
 
         {% set data_table = form.vars.data_table_view %}
@@ -469,9 +473,9 @@
                 {% if attribute(column_form, filter_name, [], 'any', true, true) is defined %}
                     {% set child = attribute(column_form, filter_name) %}
                     {% if child.operator is defined %}
-                        {{ form_widget(child.operator) }}
+                        {{ form_widget(child.operator, { attr: {'data-action': 'change->kreyu--data-table-bundle--column-filter#queueSubmit'}}) }}
                     {% endif %}
-                    {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-turbo-action': 'advance', 'data-turbo-frame': '_self', onchange: 'this.form.requestSubmit()' } }) }}
+                    {{ form_widget(child.value, { attr: { form: column_form.vars.id, 'data-action': 'input->kreyu--data-table-bundle--column-filter#queueSubmit', 'data-turbo-permanent': '' } }) }}
                 {% endif %}
             {% endif %}
         {% endif %}

--- a/src/Type/DataTableType.php
+++ b/src/Type/DataTableType.php
@@ -130,6 +130,7 @@ final class DataTableType implements DataTableTypeInterface
         if ($dataTable->getConfig()->isFiltrationEnabled()) {
             $view->vars['filtration_form'] = $this->createFiltrationFormView($view, $dataTable);
             $view->vars['column_filtration_form'] = $this->createFiltrationColumnView($view, $dataTable);
+            $view->vars['has_column_filters'] = count($view->vars['column_filtration_form']->children) > 0;
         }
 
         if ($dataTable->getConfig()->isPersonalizationEnabled()) {

--- a/tests/Unit/Filter/FilterClearUrlGeneratorTest.php
+++ b/tests/Unit/Filter/FilterClearUrlGeneratorTest.php
@@ -159,6 +159,7 @@ class FilterClearUrlGeneratorTest extends TestCase
         $filterView = $this->createMock(FilterView::class);
         $filterView->vars['name'] = $name;
         $filterView->vars['operator_selectable'] = $operatorSelectable;
+        $filterView->vars['is_header_filter'] = true;
 
         $filterView->parent = $this->createDataTableViewMock();
 


### PR DESCRIPTION
# Description

This merge request adds support for column filters, as explained in #85 

```php
$builder
    ->addColumn('name', TextColumnType::class, [
        'label' => 'Full name',
        'sort' => true,
        'filter' => StringFilterType::class,
]);
```

You can pass options to the filter using the `filter_options` array:

```php
$builder
    ->addColumn('name', TextColumnType::class, [
        'label' => 'Full name',
        'sort' => true,
        'filter' => StringFilterType::class,
        'filter_options' => [
            'operator_selectable' => true,
        ],
    ]);
```

> **Note:**  
> A field cannot have both a header filter (via `addFilter()`) and a column filter (via the column's `filter` option) at the same time.  
> Attempting to add both types of filters for the same field will result in an `InvalidArgumentException`.

## Points to check
- Verify if using a boolean to distinguish filter types is sufficient, or if we should switch to an enumeration.
- I have not tested all filter options, but the ones I tried seem to work correctly.
- Only the base.html.twig file was modified. Maybe we should improve the other template, but I'm not sure it's necessary. As you wish.