### PR TITLE
Fix symfony/http-foundation 7.4 deprecated warning

### DIFF
--- a/src/Request/HttpFoundationRequestHandler.php
+++ b/src/Request/HttpFoundationRequestHandler.php
@@ -48,7 +48,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createFiltrationFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $request->attributes->get($form->getName())) {
             $form->submit($data);
         }
 
@@ -105,7 +105,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createPersonalizationFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $request->attributes->get($form->getName())) {
             $form->submit($data);
         }
 
@@ -122,7 +122,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createExportFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $request->attributes->get($form->getName())) {
             $form->submit($data);
         }
 


### PR DESCRIPTION
Remove symfony/http-foundation deprecated message:

```
Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead.
```