### PR TITLE
Remove useless import of the bootstrap modal

### DIFF
--- a/assets/controllers/bootstrap/modal.js
+++ b/assets/controllers/bootstrap/modal.js
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus';
-import { Modal } from 'bootstrap';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {


### PR DESCRIPTION
There was a useless import in the JS file