### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,29 +14,30 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "symfony/framework-bundle": "^6.0|^7.0",
-        "symfony/translation": "^6.0|^7.0",
-        "symfony/form": "^6.0|^7.0",
-        "symfony/mime": "^6.0|^7.0",
-        "symfony/twig-bundle": "^6.0|^7.0",
+        "symfony/framework-bundle": "^6.0|^7.0|^8.0",
+        "symfony/translation": "^6.0|^7.0|^8.0",
+        "symfony/form": "^6.0|^7.0|^8.0",
+        "symfony/mime": "^6.0|^7.0|^8.0",
+        "symfony/twig-bundle": "^6.0|^7.0|^8.0",
         "twig/extra-bundle": "^3.6",
         "twig/intl-extra": "^3.6",
-        "symfony/validator": "^6.0|^7.0"
+        "symfony/validator": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3.49",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.11",
         "symfony/maker-bundle": "^1.48",
-        "symfony/security-core": "^6.2|^7.0",
+        "symfony/security-core": "^6.2|^7.0|^8.0",
         "phpoffice/phpspreadsheet": "^1.28",
-        "doctrine/orm": "^2.15",
-        "doctrine/doctrine-bundle": "^2.9",
+        "doctrine/orm": "^2.15|^3.0",
+        "doctrine/doctrine-bundle": "^2.9|^3.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.4",
         "dg/bypass-finals": "dev-master",
         "openspout/openspout": "^4.23",
-        "symfony/http-foundation": "^6.0|^7.0"
+        "symfony/http-foundation": "^6.0|^7.0|^8.0",
+        "symfony/var-exporter": "^6.4|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DataCollector/DataTableDataCollector.php
+++ b/src/DataCollector/DataTableDataCollector.php
@@ -36,11 +36,11 @@ class DataTableDataCollector extends AbstractDataCollector implements DataTableD
         }
     }
 
-    public function __sleep(): array
+    public function __serialize(): array
     {
         $this->data = $this->cloneVar($this->data)->withMaxDepth($this->maxDepth);
 
-        return parent::__sleep();
+        return parent::__serialize();
     }
 
     public static function getTemplate(): ?string

--- a/src/DataCollector/DataTableDataCollector.php
+++ b/src/DataCollector/DataTableDataCollector.php
@@ -36,11 +36,19 @@ class DataTableDataCollector extends AbstractDataCollector implements DataTableD
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function __serialize(): array
     {
         $this->data = $this->cloneVar($this->data)->withMaxDepth($this->maxDepth);
 
-        return parent::__serialize();
+        if (method_exists(parent::class, '__serialize')) {
+            return parent::__serialize();
+        }
+
+        // Symfony 7: __serialize() does not exist yet, replicate __sleep() behavior
+        return ['data' => $this->data];
     }
 
     public static function getTemplate(): ?string

--- a/src/Request/HttpFoundationRequestHandler.php
+++ b/src/Request/HttpFoundationRequestHandler.php
@@ -48,7 +48,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createFiltrationFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $this->getRequestParameter($request, $form->getName())) {
             $form->submit($data);
         }
 
@@ -105,7 +105,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createPersonalizationFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $this->getRequestParameter($request, $form->getName())) {
             $form->submit($data);
         }
 
@@ -122,13 +122,26 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
         $form = $dataTable->createExportFormBuilder()->getForm();
 
-        if ($data = $request->get($form->getName())) {
+        if ($data = $this->getRequestParameter($request, $form->getName())) {
             $form->submit($data);
         }
 
         if ($form->isSubmitted() && $form->isValid()) {
             $dataTable->setExportData($form->getData());
         }
+    }
+
+    private function getRequestParameter(Request $request, string $name): mixed
+    {
+        if ($request->query->has($name)) {
+            return $request->query->all()[$name];
+        }
+
+        if ($request->request->has($name)) {
+            return $request->request->all()[$name];
+        }
+
+        return null;
     }
 
     private function extractQueryParameter(Request $request, string $path): mixed

--- a/tests/ReflectionTrait.php
+++ b/tests/ReflectionTrait.php
@@ -8,16 +8,11 @@ trait ReflectionTrait
 {
     private function getPrivatePropertyValue(object $object, string $property): mixed
     {
-        $reflection = new \ReflectionProperty($object, $property);
-        $reflection->setAccessible(true);
-
-        return $reflection->getValue($object);
+        return (new \ReflectionProperty($object, $property))->getValue($object);
     }
 
     private function setPrivatePropertyValue(object $object, string $property, mixed $value): void
     {
-        $reflection = new \ReflectionProperty($object, $property);
-        $reflection->setAccessible(true);
-        $reflection->setValue($object, $value);
+        (new \ReflectionProperty($object, $property))->setValue($object, $value);
     }
 }

--- a/tests/Unit/Bridge/Doctrine/Orm/Filter/DoctrineOrmFilterHandlerTest.php
+++ b/tests/Unit/Bridge/Doctrine/Orm/Filter/DoctrineOrmFilterHandlerTest.php
@@ -60,8 +60,10 @@ class DoctrineOrmFilterHandlerTest extends TestCase
         ($queryBuilder = $this->createQueryBuilderMock())
             ->expects($this->once())
             ->method('andWhere')
-            ->willReturnCallback(function (mixed $expression) {
+            ->willReturnCallback(function (mixed $expression) use (&$queryBuilder) {
                 $this->assertEquals('expression', $expression);
+
+                return $queryBuilder;
             });
 
         $this->query->method('getQueryBuilder')->willReturn($queryBuilder);
@@ -74,10 +76,12 @@ class DoctrineOrmFilterHandlerTest extends TestCase
         ($queryBuilder = $this->createQueryBuilderMock())
             ->expects($this->once())
             ->method('setParameter')
-            ->willReturnCallback(function ($name, $value, $type) {
+            ->willReturnCallback(function ($name, $value, $type) use (&$queryBuilder) {
                 $this->assertEquals('foo', $name);
                 $this->assertEquals('bar', $value);
                 $this->assertNull($type);
+
+                return $queryBuilder;
             });
 
         $this->query->method('getQueryBuilder')->willReturn($queryBuilder);
@@ -85,15 +89,17 @@ class DoctrineOrmFilterHandlerTest extends TestCase
         $this->createHandler(parameters: [new Parameter('foo', 'bar')])->handle($this->query, $this->data, $this->filter);
     }
 
-    public function testItSetsParameterWithTypeSpecified()
+    public function testItSetsParameterWithTypeSpecified(): void
     {
         ($queryBuilder = $this->createQueryBuilderMock())
             ->expects($this->once())
             ->method('setParameter')
-            ->willReturnCallback(function ($name, $value, $type) {
+            ->willReturnCallback(function ($name, $value, $type) use (&$queryBuilder) {
                 $this->assertEquals('foo', $name);
                 $this->assertEquals('bar', $value);
                 $this->assertEquals('date_immutable', $type);
+
+                return $queryBuilder;
             });
 
         $this->query->method('getQueryBuilder')->willReturn($queryBuilder);

--- a/tests/Unit/Bridge/Doctrine/Orm/Fixtures/TestEntityManagerFactory.php
+++ b/tests/Unit/Bridge/Doctrine/Orm/Fixtures/TestEntityManagerFactory.php
@@ -21,6 +21,10 @@ class TestEntityManagerFactory
 
         $config = ORMSetup::createAttributeMetadataConfiguration([], true);
 
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        }
+
         $connection = DriverManager::getConnection([
             'driver' => 'pdo_sqlite',
             'memory' => true,

--- a/tests/Unit/DataCollector/DataTableDataCollectorTest.php
+++ b/tests/Unit/DataCollector/DataTableDataCollectorTest.php
@@ -418,14 +418,10 @@ class DataTableDataCollectorTest extends TestCase
         $headerView->vars = ['label' => 'Name', 'attr' => []];
         $this->collector->collectColumnHeaderView($column, $headerView);
 
-        $serialized = $this->collector->__serialize();
-        $this->assertArrayHasKey('data', $serialized);
+        $restoredCollector = unserialize(serialize($this->collector));
 
-        $restoredCollector = new DataTableDataCollector($this->dataExtractor);
-        $restoredCollector->__unserialize($serialized);
-
-        $data = $restoredCollector->getData();
-        $this->assertInstanceOf(Data::class, $data);
+        $this->assertInstanceOf(DataTableDataCollector::class, $restoredCollector);
+        $this->assertInstanceOf(Data::class, $restoredCollector->getData());
     }
 
     private function assertActionViewCollected(ActionContext $context, string $dataKey): void

--- a/tests/Unit/DataCollector/DataTableDataCollectorTest.php
+++ b/tests/Unit/DataCollector/DataTableDataCollectorTest.php
@@ -1,0 +1,528 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreyu\Bundle\DataTableBundle\Tests\Unit\DataCollector;
+
+use Kreyu\Bundle\DataTableBundle\Action\ActionConfigInterface;
+use Kreyu\Bundle\DataTableBundle\Action\ActionContext;
+use Kreyu\Bundle\DataTableBundle\Action\ActionInterface;
+use Kreyu\Bundle\DataTableBundle\Action\ActionView;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnHeaderView;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnInterface;
+use Kreyu\Bundle\DataTableBundle\Column\ColumnValueView;
+use Kreyu\Bundle\DataTableBundle\DataCollector\DataTableDataCollector;
+use Kreyu\Bundle\DataTableBundle\DataCollector\DataTableDataExtractorInterface;
+use Kreyu\Bundle\DataTableBundle\DataTableConfigInterface;
+use Kreyu\Bundle\DataTableBundle\DataTableInterface;
+use Kreyu\Bundle\DataTableBundle\DataTableView;
+use Kreyu\Bundle\DataTableBundle\Exporter\ExporterInterface;
+use Kreyu\Bundle\DataTableBundle\Filter\FilterData;
+use Kreyu\Bundle\DataTableBundle\Filter\FilterInterface;
+use Kreyu\Bundle\DataTableBundle\Filter\FilterView;
+use Kreyu\Bundle\DataTableBundle\Filter\FiltrationData;
+use Kreyu\Bundle\DataTableBundle\Filter\Operator;
+use Kreyu\Bundle\DataTableBundle\HeaderRowView;
+use Kreyu\Bundle\DataTableBundle\Pagination\PaginationData;
+use Kreyu\Bundle\DataTableBundle\Pagination\PaginationInterface;
+use Kreyu\Bundle\DataTableBundle\Sorting\SortingColumnData;
+use Kreyu\Bundle\DataTableBundle\Sorting\SortingData;
+use Kreyu\Bundle\DataTableBundle\ValueRowView;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+class DataTableDataCollectorTest extends TestCase
+{
+    private MockObject&DataTableDataExtractorInterface $dataExtractor;
+    private DataTableDataCollector $collector;
+
+    protected function setUp(): void
+    {
+        $this->dataExtractor = $this->createMock(DataTableDataExtractorInterface::class);
+        $this->collector = new DataTableDataCollector($this->dataExtractor);
+    }
+
+    public function testCollectDoesNothing(): void
+    {
+        $this->collector->collect(new Request(), new Response());
+
+        $this->assertSame([], $this->collector->getData());
+    }
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            '@KreyuDataTable/data_collector/template.html.twig',
+            DataTableDataCollector::getTemplate(),
+        );
+    }
+
+    public function testCollectDataTable(): void
+    {
+        $column = $this->createColumnMock('id');
+        $filter = $this->createFilterMock('name');
+        $action = $this->createActionMock('edit');
+        $rowAction = $this->createActionMock('view');
+        $batchAction = $this->createActionMock('delete');
+        $exporter = $this->createExporterMock('csv');
+
+        $config = $this->createMock(DataTableConfigInterface::class);
+        $config->method('isPaginationEnabled')->willReturn(true);
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('getColumns')->willReturn(['id' => $column]);
+        $dataTable->method('getFilters')->willReturn(['name' => $filter]);
+        $dataTable->method('getActions')->willReturn(['edit' => $action]);
+        $dataTable->method('getRowActions')->willReturn(['view' => $rowAction]);
+        $dataTable->method('getBatchActions')->willReturn(['delete' => $batchAction]);
+        $dataTable->method('getExporters')->willReturn(['csv' => $exporter]);
+        $dataTable->method('getConfig')->willReturn($config);
+
+        $this->dataExtractor->method('extractDataTableConfiguration')->willReturn(['type_class' => 'App\\DataTable']);
+        $this->dataExtractor->method('extractColumnConfiguration')->willReturn(['column_config' => true]);
+        $this->dataExtractor->method('extractFilterConfiguration')->willReturn(['filter_config' => true]);
+        $this->dataExtractor->method('extractActionConfiguration')->willReturnCallback(
+            fn (ActionInterface $a) => ['action_name' => $a->getName()],
+        );
+        $this->dataExtractor->method('extractExporterConfiguration')->willReturn(['exporter_config' => true]);
+
+        $this->collector->collectDataTable($dataTable);
+
+        $data = $this->collector->getData();
+
+        $this->assertArrayHasKey('users', $data);
+        $this->assertSame('App\\DataTable', $data['users']['type_class']);
+        $this->assertSame(['column_config' => true], $data['users']['columns']['id']);
+        $this->assertSame(['filter_config' => true], $data['users']['filters']['name']);
+        $this->assertSame(['action_name' => 'edit'], $data['users']['actions']['edit']);
+        $this->assertSame(['action_name' => 'view'], $data['users']['row_actions']['view']);
+        $this->assertSame(['action_name' => 'delete'], $data['users']['batch_actions']['delete']);
+        $this->assertSame(['exporter_config' => true], $data['users']['exporters']['csv']);
+    }
+
+    public function testCollectDataTableWithPaginationDisabledCollectsTotalCount(): void
+    {
+        $config = $this->createMock(DataTableConfigInterface::class);
+        $config->method('isPaginationEnabled')->willReturn(false);
+
+        $dataTable = $this->createDataTableMock('products');
+        $dataTable->method('getColumns')->willReturn([]);
+        $dataTable->method('getFilters')->willReturn([]);
+        $dataTable->method('getActions')->willReturn([]);
+        $dataTable->method('getRowActions')->willReturn([]);
+        $dataTable->method('getBatchActions')->willReturn([]);
+        $dataTable->method('getExporters')->willReturn([]);
+        $dataTable->method('getConfig')->willReturn($config);
+        $dataTable->method('getItems')->willReturn(new \ArrayIterator([1, 2, 3]));
+
+        $this->dataExtractor->method('extractDataTableConfiguration')->willReturn([]);
+
+        $this->collector->collectDataTable($dataTable);
+
+        $data = $this->collector->getData();
+        $this->assertSame(3, $data['products']['total_count']);
+    }
+
+    public function testCollectDataTableView(): void
+    {
+        $this->initializeCollectorWithDataTable('orders');
+
+        $view = new DataTableView();
+        $view->vars = ['foo' => 'bar', 'baz' => 'qux'];
+
+        $dataTable = $this->createDataTableMock('orders');
+        $this->dataExtractor->method('extractValueRows')->willReturn([['row1'], ['row2']]);
+
+        $this->collector->collectDataTableView($dataTable, $view);
+
+        $data = $this->collector->getData();
+        $this->assertSame(['baz' => 'qux', 'foo' => 'bar'], $data['orders']['view_vars']);
+        $this->assertSame([['row1'], ['row2']], $data['orders']['value_rows']);
+    }
+
+    public function testCollectColumnHeaderView(): void
+    {
+        $this->initializeCollectorWithDataTable('users', columns: ['email']);
+
+        $column = $this->createColumnMock('email');
+        $columnDataTable = $this->createDataTableMock('users');
+        $column->method('getDataTable')->willReturn($columnDataTable);
+
+        $headerView = new ColumnHeaderView(new HeaderRowView(new DataTableView()));
+        $headerView->vars = ['label' => 'Email', 'attr' => ['class' => 'email']];
+
+        $this->collector->collectColumnHeaderView($column, $headerView);
+
+        $data = $this->collector->getData();
+        $this->assertSame(
+            ['attr' => ['class' => 'email'], 'label' => 'Email'],
+            $data['users']['columns']['email']['header_view_vars'],
+        );
+    }
+
+    public function testCollectColumnValueViewSkipsNestedColumns(): void
+    {
+        $this->initializeCollectorWithDataTable('users', columns: ['tags']);
+
+        $column = $this->createColumnMock('tags');
+        $columnDataTable = $this->createDataTableMock('users');
+        $column->method('getDataTable')->willReturn($columnDataTable);
+
+        $dataTableView = new DataTableView();
+        $parentRow = new ValueRowView($dataTableView, 0, ['id' => 1]);
+        $parentRow->origin = $parentRow;
+
+        $valueView = new ColumnValueView($parentRow);
+        $valueView->vars = ['value' => 'test'];
+
+        $this->collector->collectColumnValueView($column, $valueView);
+
+        $data = $this->collector->getData();
+        $this->assertArrayNotHasKey('value_view_vars', $data['users']['columns']['tags']);
+    }
+
+    public function testCollectColumnValueViewCollectsTopLevelColumns(): void
+    {
+        $this->initializeCollectorWithDataTable('users', columns: ['name']);
+
+        $column = $this->createColumnMock('name');
+        $columnDataTable = $this->createDataTableMock('users');
+        $column->method('getDataTable')->willReturn($columnDataTable);
+
+        $dataTableView = new DataTableView();
+        $parentRow = new ValueRowView($dataTableView, 0, ['id' => 1]);
+
+        $valueView = new ColumnValueView($parentRow);
+        $valueView->vars = ['value' => 'John', 'attr' => []];
+
+        $this->collector->collectColumnValueView($column, $valueView);
+
+        $data = $this->collector->getData();
+        $this->assertSame(
+            ['attr' => [], 'value' => 'John'],
+            $data['users']['columns']['name']['value_view_vars'],
+        );
+    }
+
+    public function testCollectSortingData(): void
+    {
+        $this->initializeCollectorWithDataTable('users', columns: ['name', 'email']);
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('hasColumn')->willReturnCallback(fn (string $name) => in_array($name, ['name', 'email']));
+
+        $nameColumn = $this->createColumnMock('name');
+        $nameDataTable = $this->createDataTableMock('users');
+        $nameColumn->method('getDataTable')->willReturn($nameDataTable);
+
+        $emailColumn = $this->createColumnMock('email');
+        $emailDataTable = $this->createDataTableMock('users');
+        $emailColumn->method('getDataTable')->willReturn($emailDataTable);
+
+        $dataTable->method('getColumn')->willReturnMap([
+            ['name', $nameColumn],
+            ['email', $emailColumn],
+        ]);
+
+        $sortingData = new SortingData([
+            new SortingColumnData('name', 'asc'),
+            new SortingColumnData('email', 'desc'),
+        ]);
+
+        $this->collector->collectSortingData($dataTable, $sortingData);
+
+        $data = $this->collector->getData();
+        $this->assertSame('asc', $data['users']['columns']['name']['sort_direction']);
+        $this->assertSame('desc', $data['users']['columns']['email']['sort_direction']);
+    }
+
+    public function testCollectSortingDataSkipsUnknownColumns(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('hasColumn')->willReturn(false);
+
+        $sortingData = new SortingData([
+            new SortingColumnData('nonexistent', 'asc'),
+        ]);
+
+        $this->collector->collectSortingData($dataTable, $sortingData);
+
+        $data = $this->collector->getData();
+        $this->assertArrayNotHasKey('nonexistent', $data['users']['columns']);
+    }
+
+    public function testCollectPaginationData(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $pagination = $this->createMock(PaginationInterface::class);
+        $pagination->method('getTotalItemCount')->willReturn(100);
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('getPagination')->willReturn($pagination);
+
+        $paginationData = new PaginationData(3, 25);
+
+        $this->collector->collectPaginationData($dataTable, $paginationData);
+
+        $data = $this->collector->getData();
+        $this->assertSame(3, $data['users']['page']);
+        $this->assertSame(25, $data['users']['per_page']);
+        $this->assertSame(100, $data['users']['total_count']);
+    }
+
+    public function testCollectFilterView(): void
+    {
+        $this->initializeCollectorWithDataTable('users', filters: ['status']);
+
+        $filter = $this->createFilterMock('status');
+        $filterDataTable = $this->createDataTableMock('users');
+        $filter->method('getDataTable')->willReturn($filterDataTable);
+
+        $filterView = new FilterView(new DataTableView());
+        $filterView->vars = ['label' => 'Status', 'attr' => []];
+
+        $this->collector->collectFilterView($filter, $filterView);
+
+        $data = $this->collector->getData();
+        $this->assertSame(
+            ['attr' => [], 'label' => 'Status'],
+            $data['users']['filters']['status']['view_vars'],
+        );
+    }
+
+    public function testCollectFiltrationData(): void
+    {
+        $this->initializeCollectorWithDataTable('users', filters: ['status', 'role']);
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('hasFilter')->willReturnCallback(fn (string $name) => in_array($name, ['status', 'role']));
+
+        $statusFilter = $this->createFilterMock('status');
+        $statusDataTable = $this->createDataTableMock('users');
+        $statusFilter->method('getDataTable')->willReturn($statusDataTable);
+
+        $roleFilter = $this->createFilterMock('role');
+        $roleDataTable = $this->createDataTableMock('users');
+        $roleFilter->method('getDataTable')->willReturn($roleDataTable);
+
+        $dataTable->method('getFilter')->willReturnMap([
+            ['status', $statusFilter],
+            ['role', $roleFilter],
+        ]);
+
+        $statusFilterData = new FilterData('active', Operator::Equals);
+        $roleFilterData = new FilterData('admin');
+
+        $filtrationData = new FiltrationData([
+            'status' => $statusFilterData,
+            'role' => $roleFilterData,
+        ]);
+
+        $this->collector->collectFiltrationData($dataTable, $filtrationData);
+
+        $data = $this->collector->getData();
+        $this->assertSame($statusFilterData, $data['users']['filters']['status']['data']);
+        $this->assertSame('Equals', $data['users']['filters']['status']['operator_label']);
+        $this->assertSame($roleFilterData, $data['users']['filters']['role']['data']);
+        $this->assertNull($data['users']['filters']['role']['operator_label']);
+    }
+
+    public function testCollectFiltrationDataSkipsUnknownFilters(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('hasFilter')->willReturn(false);
+
+        $filtrationData = new FiltrationData([
+            'nonexistent' => new FilterData('value'),
+        ]);
+
+        $this->collector->collectFiltrationData($dataTable, $filtrationData);
+
+        $data = $this->collector->getData();
+        $this->assertArrayNotHasKey('nonexistent', $data['users']['filters']);
+    }
+
+    public function testCollectActionViewForGlobalAction(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $this->assertActionViewCollected(ActionContext::Global, 'actions');
+    }
+
+    public function testCollectActionViewForRowAction(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $this->assertActionViewCollected(ActionContext::Row, 'row_actions');
+    }
+
+    public function testCollectActionViewForBatchAction(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $this->assertActionViewCollected(ActionContext::Batch, 'batch_actions');
+    }
+
+    public function testCollectDataTableMergesWithExistingData(): void
+    {
+        $config = $this->createMock(DataTableConfigInterface::class);
+        $config->method('isPaginationEnabled')->willReturn(true);
+
+        $dataTable = $this->createDataTableMock('users');
+        $dataTable->method('getColumns')->willReturn([]);
+        $dataTable->method('getFilters')->willReturn([]);
+        $dataTable->method('getActions')->willReturn([]);
+        $dataTable->method('getRowActions')->willReturn([]);
+        $dataTable->method('getBatchActions')->willReturn([]);
+        $dataTable->method('getExporters')->willReturn([]);
+        $dataTable->method('getConfig')->willReturn($config);
+
+        $this->dataExtractor->method('extractDataTableConfiguration')->willReturn(['type_class' => 'App\\DataTable']);
+
+        $this->collector->collectDataTable($dataTable);
+        $this->collector->collectDataTable($dataTable);
+
+        $data = $this->collector->getData();
+        $this->assertArrayHasKey('users', $data);
+        $this->assertSame('App\\DataTable', $data['users']['type_class']);
+    }
+
+    public function testReset(): void
+    {
+        $this->initializeCollectorWithDataTable('users');
+
+        $this->assertNotEmpty($this->collector->getData());
+
+        $this->collector->reset();
+
+        $this->assertSame([], $this->collector->getData());
+    }
+
+    public function testDataSurvivesSerializationRoundtrip(): void
+    {
+        $this->initializeCollectorWithDataTable('users', columns: ['name']);
+
+        $column = $this->createColumnMock('name');
+        $columnDataTable = $this->createDataTableMock('users');
+        $column->method('getDataTable')->willReturn($columnDataTable);
+
+        $headerView = new ColumnHeaderView(new HeaderRowView(new DataTableView()));
+        $headerView->vars = ['label' => 'Name', 'attr' => []];
+        $this->collector->collectColumnHeaderView($column, $headerView);
+
+        $serialized = $this->collector->__serialize();
+        $this->assertArrayHasKey('data', $serialized);
+
+        $restoredCollector = new DataTableDataCollector($this->dataExtractor);
+        $restoredCollector->__unserialize($serialized);
+
+        $data = $restoredCollector->getData();
+        $this->assertInstanceOf(Data::class, $data);
+    }
+
+    private function assertActionViewCollected(ActionContext $context, string $dataKey): void
+    {
+        $actionConfig = $this->createMock(ActionConfigInterface::class);
+        $actionConfig->method('getContext')->willReturn($context);
+
+        $action = $this->createActionMock('test_action');
+        $actionDataTable = $this->createDataTableMock('users');
+        $action->method('getDataTable')->willReturn($actionDataTable);
+        $action->method('getConfig')->willReturn($actionConfig);
+
+        $actionView = new ActionView(new DataTableView());
+        $actionView->vars = ['label' => 'Test', 'attr' => []];
+
+        $this->collector->collectActionView($action, $actionView);
+
+        $data = $this->collector->getData();
+        $this->assertSame(
+            ['attr' => [], 'label' => 'Test'],
+            $data['users'][$dataKey]['test_action']['view_vars'],
+        );
+    }
+
+    private function initializeCollectorWithDataTable(
+        string $name,
+        array $columns = [],
+        array $filters = [],
+    ): void {
+        $config = $this->createMock(DataTableConfigInterface::class);
+        $config->method('isPaginationEnabled')->willReturn(true);
+
+        $columnMocks = [];
+        foreach ($columns as $colName) {
+            $columnMocks[$colName] = $this->createColumnMock($colName);
+        }
+
+        $filterMocks = [];
+        foreach ($filters as $filterName) {
+            $filterMocks[$filterName] = $this->createFilterMock($filterName);
+        }
+
+        $dataTable = $this->createDataTableMock($name);
+        $dataTable->method('getColumns')->willReturn($columnMocks);
+        $dataTable->method('getFilters')->willReturn($filterMocks);
+        $dataTable->method('getActions')->willReturn([]);
+        $dataTable->method('getRowActions')->willReturn([]);
+        $dataTable->method('getBatchActions')->willReturn([]);
+        $dataTable->method('getExporters')->willReturn([]);
+        $dataTable->method('getConfig')->willReturn($config);
+
+        $this->dataExtractor->method('extractDataTableConfiguration')->willReturn([]);
+        $this->dataExtractor->method('extractColumnConfiguration')->willReturn([]);
+        $this->dataExtractor->method('extractFilterConfiguration')->willReturn([]);
+        $this->dataExtractor->method('extractActionConfiguration')->willReturn([]);
+        $this->dataExtractor->method('extractExporterConfiguration')->willReturn([]);
+
+        $this->collector->collectDataTable($dataTable);
+    }
+
+    private function createDataTableMock(string $name): MockObject&DataTableInterface
+    {
+        $dataTable = $this->createMock(DataTableInterface::class);
+        $dataTable->method('getName')->willReturn($name);
+
+        return $dataTable;
+    }
+
+    private function createColumnMock(string $name): MockObject&ColumnInterface
+    {
+        $column = $this->createMock(ColumnInterface::class);
+        $column->method('getName')->willReturn($name);
+
+        return $column;
+    }
+
+    private function createFilterMock(string $name): MockObject&FilterInterface
+    {
+        $filter = $this->createMock(FilterInterface::class);
+        $filter->method('getName')->willReturn($name);
+
+        return $filter;
+    }
+
+    private function createActionMock(string $name): MockObject&ActionInterface
+    {
+        $action = $this->createMock(ActionInterface::class);
+        $action->method('getName')->willReturn($name);
+
+        return $action;
+    }
+
+    private function createExporterMock(string $name): MockObject&ExporterInterface
+    {
+        $exporter = $this->createMock(ExporterInterface::class);
+        $exporter->method('getName')->willReturn($name);
+
+        return $exporter;
+    }
+}


### PR DESCRIPTION
This change allows the installation with Symfony 8. It also installs `symfony/var-exporter` to be compatible with Doctrine ORM 3.0.